### PR TITLE
fix: stack too deep error

### DIFF
--- a/test/KintoWallet.t.sol
+++ b/test/KintoWallet.t.sol
@@ -268,12 +268,16 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         calls[0] = abi.encodeWithSignature('setAppWhitelist(address[],bool[])',apps, flags);
         calls[1] = abi.encodeWithSignature('increment()');
         calls[2] = abi.encodeWithSignature('increment()');
+
+        OperationParams memory opParams = OperationParams({
+            targetContracts: targets,
+            values: values,
+            bytesOps: calls
+        });
         UserOperation memory userOp = this.createUserOperationBatchWithPaymaster(
             _chainID,
             address(_kintoWalletv1), startingNonce, privateKeys,
-            targets,
-            values,
-            calls,
+            opParams,
             address(_paymaster));
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
@@ -312,12 +316,15 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         calls[1] = abi.encodeWithSignature('increment()');
         calls[2] = abi.encodeWithSignature('increment()');
         // Let's send both transactions via batch
+        OperationParams memory opParams = OperationParams({
+            targetContracts: targets,
+            values: values,
+            bytesOps: calls
+        });
         UserOperation memory userOp = this.createUserOperationBatchWithPaymaster(
             _chainID,
             address(_kintoWalletv1), startingNonce, privateKeys,
-            targets,
-            values,
-            calls,
+            opParams,
             address(_paymaster));
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;


### PR DESCRIPTION
when running `fix coverage`, it throws the `stack too deep error` (see error below).

<img width="1488" alt="image" src="https://github.com/KintoXYZ/kinto-core/assets/4473536/eca641b5-af2c-4cba-8bd6-bb00fb8b9761">

i've searched and found where was the issue so this PR fixes it.

