### PR TITLE
remove `testFail` from tests and prefer `vm.expectRevert`

### DIFF
--- a/.github/workflows/gas-diff.yml
+++ b/.github/workflows/gas-diff.yml
@@ -1,0 +1,57 @@
+name: Report gas diff
+
+on: 
+  workflow_call:
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     # Optionally configure to run only for changes in specific files. For example:
+#     # paths:
+#     # - src/**
+#     # - test/**
+#     # - foundry.toml
+#     # - remappings.txt
+#     # - .github/workflows/foundry-gas-diff.yml
+
+jobs:
+  compare_gas_reports:
+    name: Compare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with: 
+          submodules: recursive
+      
+      - uses: ./.github/actions/install
+
+      - name: Build contracts
+        run: forge build --sizes
+
+      - name: Check gas snapshots
+        run: forge snapshot --diff
+
+      - name: Run tests
+        run: forge test --gas-report > gasreport.ansi
+        env:
+          # make fuzzing semi-deterministic to avoid noisy gas cost estimation
+          # due to non-deterministic fuzzing (but still use pseudo-random fuzzing seeds)
+          FOUNDRY_FUZZ_SEED: 0x${{ github.event.pull_request.base.sha || github.sha }}
+
+      - name: Compare gas reports
+        uses: Rubilmax/foundry-gas-diff@v3.16
+        with:
+          summaryQuantile: 0.9 # only display the 10% most significant gas diffs in the summary (defaults to 20%)
+          sortCriteria: avg,max # sort diff rows by criteria
+          sortOrders: desc,asc # and directions
+          ignore: test-foundry/**/* # filter out gas reports from specific paths (test/ is included by default)
+        id: gas_diff
+
+      - name: Add gas diff to sticky comment
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # delete the comment in case changes no longer impact gas costs
+          delete: ${{ !steps.gas_diff.outputs.markdown }}
+          message: ${{ steps.gas_diff.outputs.markdown }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,3 +23,9 @@ jobs:
     name: Slither analysis
     uses: ./.github/workflows/slither.yml
     secrets: inherit
+
+  gas-diff:
+    name: Gas diff
+    uses: ./.github/workflows/gas-diff.yml
+    secrets: inherit
+  

--- a/src/wallet/KintoWallet.sol
+++ b/src/wallet/KintoWallet.sol
@@ -121,7 +121,7 @@ contract KintoWallet is Initializable, BaseAccount, TokenCallbackHandler, IKinto
     /* ============ Signer Management ============ */
 
     /**
-     * @dev Change the signer policy
+     * @dev Change signer policy
      * @param policy new policy
      */
     function setSignerPolicy(uint8 policy) public override onlySelf {
@@ -132,11 +132,11 @@ contract KintoWallet is Initializable, BaseAccount, TokenCallbackHandler, IKinto
     }
 
     /**
-     * @dev Changed the signers
+     * @dev Change signers and policy (if new)
      * @param newSigners new signers array
      */
     function resetSigners(address[] calldata newSigners, uint8 policy) external override onlySelf {
-        require(newSigners[0] == owners[0], "KW-rs: first signer must same unless recovery");
+        require(newSigners[0] == owners[0], "KW-rs: first signer must be the same unless recovery");
         _resetSigners(newSigners, policy);
     }
 
@@ -220,7 +220,7 @@ contract KintoWallet is Initializable, BaseAccount, TokenCallbackHandler, IKinto
     }
 
     /**
-     * @dev Allos the wallet to transact with a specific app
+     * @dev Allows the wallet to transact with a specific app
      * @param apps apps array
      * @param flags whether to allow or disallow the app
      */

--- a/test/DeployTests.t.sol
+++ b/test/DeployTests.t.sol
@@ -59,15 +59,6 @@ contract DeveloperDeployTest is Create2Helper, UserOp, AATestScaffolding {
 
     uint256 _chainID = 1;
 
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address payable _user = payable(vm.addr(3));
-    address _user2 = address(4);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
-    address payable _funder = payable(vm.addr(8));
-
     UUPSProxy _proxyc;
     Counter _counter;
     CounterInitializable _counterInit;
@@ -77,7 +68,7 @@ contract DeveloperDeployTest is Create2Helper, UserOp, AATestScaffolding {
         vm.startPrank(address(1));
         _owner.transfer(1e18);
         vm.stopPrank();
-        deployAAScaffolding(_owner, _kycProvider, _recoverer);
+        deployAAScaffolding(_owner, 1, _kycProvider, _recoverer);
         vm.startPrank(_owner);
 
         address created =

--- a/test/ETHPriceIsRight.t.sol
+++ b/test/ETHPriceIsRight.t.sol
@@ -63,10 +63,10 @@ contract ETHPriceIsRightTest is Test {
         assertEq(_priceIsRight.avgGuess(), 3000 ether);
     }
 
-    function testFailCannotEnterGuessAfterTime() public {
-        vm.startPrank(_user);
+    function test_RevertWhen_CannotEnterGuessAfterTime() public {
         vm.warp(_priceIsRight.END_ENTER_TIMESTAMP() + 1);
+
+        vm.expectRevert("You cannot enter guesses anymore");
         _priceIsRight.enterGuess(2000 ether);
-        vm.stopPrank();
     }
 }

--- a/test/KYCViewer.t.sol
+++ b/test/KYCViewer.t.sol
@@ -39,14 +39,6 @@ contract KYCViewerTest is Create2Helper, UserOp, AATestScaffolding {
 
     uint256 _chainID = 1;
 
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address payable _user = payable(vm.addr(3));
-    address _user2 = address(4);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
-    address payable _funder = payable(vm.addr(8));
     UUPSProxy _proxyViewer;
     KYCViewer _implkycViewer;
     KYCViewerV2 _implkycViewerV2;
@@ -58,7 +50,7 @@ contract KYCViewerTest is Create2Helper, UserOp, AATestScaffolding {
         vm.startPrank(address(1));
         _owner.transfer(1e18);
         vm.stopPrank();
-        deployAAScaffolding(_owner, _kycProvider, _recoverer);
+        deployAAScaffolding(_owner, 1, _kycProvider, _recoverer);
         vm.startPrank(_owner);
         _implkycViewer = new KYCViewer{salt: 0}(address(_walletFactory));
         // deploy _proxy contract and point it to _implementation
@@ -90,7 +82,7 @@ contract KYCViewerTest is Create2Helper, UserOp, AATestScaffolding {
         vm.stopPrank();
     }
 
-    function testFailOthersCannotUpgradeFactory() public {
+    function test_RevertWhen_OthersCannotUpgradeFactory() public {
         KYCViewerV2 _implementationV2 = new KYCViewerV2(address(_walletFactory));
         _kycViewer.upgradeTo(address(_implementationV2));
         // re-wrap the _proxy

--- a/test/KYCViewer.t.sol
+++ b/test/KYCViewer.t.sol
@@ -84,10 +84,8 @@ contract KYCViewerTest is Create2Helper, UserOp, AATestScaffolding {
 
     function test_RevertWhen_OthersCannotUpgradeFactory() public {
         KYCViewerV2 _implementationV2 = new KYCViewerV2(address(_walletFactory));
+        vm.expectRevert("only owner");
         _kycViewer.upgradeTo(address(_implementationV2));
-        // re-wrap the _proxy
-        _kycViewer2 = KYCViewerV2(address(_kycViewer));
-        assertEq(_kycViewer2.newFunction(), 1);
     }
 
     /* ============ Viewer Tests ============ */

--- a/test/KintoEntryPoint.t.sol
+++ b/test/KintoEntryPoint.t.sol
@@ -25,20 +25,12 @@ contract KintoEntryPointTest is AATestScaffolding, UserOp {
 
     uint256 _chainID = 1;
 
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address _user = vm.addr(3);
-    address _user2 = vm.addr(5);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
-
     function setUp() public {
         vm.chainId(_chainID);
         vm.startPrank(address(1));
         _owner.transfer(1e18);
         vm.stopPrank();
-        deployAAScaffolding(_owner, _kycProvider, _recoverer);
+        deployAAScaffolding(_owner, 1, _kycProvider, _recoverer);
     }
 
     function testUp() public {

--- a/test/KintoWallet.t.sol
+++ b/test/KintoWallet.t.sol
@@ -49,24 +49,52 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
     using SignatureChecker for address;
 
     KintoWalletv2 _kintoWalletv2;
+    uint256[] privateKeys;
 
     uint256 _chainID = 1;
 
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address _user = vm.addr(3);
-    address _user2 = vm.addr(5);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
+    // private keys
+    uint256 _ownerPk = 1;
+    uint256 _secondownerPk = 2;
+    uint256 _userPk = 3;
+    uint256 _user2Pk = 4;
+    uint256 _upgraderPk = 5;
+    uint256 _kycProviderPk = 6;
+    uint256 _recovererPk = 7;
+
+    // users
+    address payable _owner = payable(vm.addr(_ownerPk));
+    address payable _secondowner = payable(vm.addr(_secondownerPk));
+    address payable _user = payable(vm.addr(_userPk));
+    address payable _user2 = payable(vm.addr(_user2Pk));
+    address payable _upgrader = payable(vm.addr(_upgraderPk));
+    address payable _kycProvider = payable(vm.addr(_kycProviderPk));
+    address payable _recoverer = payable(vm.addr(_recovererPk));
+
+    // events
+    event UserOperationRevertReason(
+        bytes32 indexed userOpHash, address indexed sender, uint256 nonce, bytes revertReason
+    );
+    event KintoWalletInitialized(IEntryPoint indexed entryPoint, address indexed owner);
+    event WalletPolicyChanged(uint256 newPolicy, uint256 oldPolicy);
+    event RecovererChanged(address indexed newRecoverer, address indexed recoverer);
 
     function setUp() public {
         vm.chainId(_chainID);
-        vm.startPrank(address(1));
+
+        vm.prank(address(1));
         _owner.transfer(1e18);
-        vm.stopPrank();
-        deployAAScaffolding(_owner, _kycProvider, _recoverer);
-        _setPaymasterForContract(address(_kintoWalletv1));
+
+        deployAAScaffolding(_owner, 1, _kycProvider, _recoverer);
+
+        // Add paymaster to _kintoWalletv1
+        _fundPaymasterForContract(address(_kintoWalletv1));
+
+        // Default tests to use 1 private key for simplicity
+        privateKeys = new uint256[](1);
+
+        // Default tests to use _ownerPk unless otherwise specified
+        privateKeys[0] = _ownerPk;
     }
 
     function testUp() public {
@@ -76,17 +104,17 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
     /* ============ Upgrade Tests ============ */
 
-    function testFailOwnerCannotUpgrade() public {
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_owner);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+    function test_RevertWhen_OwnerCannotUpgrade() public {
+        // deploy a KintoWalletv2
         KintoWalletv2 _implementationV2 = new KintoWalletv2(_entryPoint, _kintoIDv1);
+
+        uint256 nonce = _kintoWalletv1.getNonce();
+
+        // try calling upgradeTo from _owner wallet to upgrade _owner wallet
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -95,54 +123,73 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point and expect a revert event
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOp),
+            userOp.sender,
+            userOp.nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        _kintoWalletv2 = KintoWalletv2(payable(address(_kintoWalletv1)));
-        assertEq(_kintoWalletv2.newFunction(), 1);
-        vm.stopPrank();
     }
 
-    function testFailOthersCannotUpgrade() public {
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_owner);
+    function test_RevertWhen_OthersCannotUpgrade() public {
+        // create a wallet for _user
+        approveKYC(_user, _userPk);
+        IKintoWallet userWallet = _walletFactory.createAccount(_user, _recoverer, 0);
+
+        // deploy a KintoWalletv2
         KintoWalletv2 _implementationV2 = new KintoWalletv2(_entryPoint, _kintoIDv1);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 3;
+
+        // try calling upgradeTo from _user wallet to upgrade _owner wallet
+        uint256 nonce = userWallet.getNonce();
+        privateKeys[0] = _userPk;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
-            address(_user),
-            startingNonce,
+            address(userWallet),
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
             abi.encodeWithSignature("upgradeTo(address)", address(_implementationV2)),
             address(_paymaster)
         );
+
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        // @dev handleOps seems to fail silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOp),
+            userOp.sender,
+            userOp.nonce,
+            bytes("") // todo: add revert reason
+        );
+
         _entryPoint.handleOps(userOps, payable(_owner));
-        _kintoWalletv2 = KintoWalletv2(payable(address(_kintoWalletv1)));
-        assertEq(_kintoWalletv2.newFunction(), 1);
+
         vm.stopPrank();
     }
 
     /* ============ One Signer Account Transaction Tests ============ */
 
-    function testFailSendingTransactionDirectly() public {
-        vm.startPrank(_owner);
-        // Let's deploy the counter contract
+    function test_RevertWhen_SendingTransactionDirectlyAndPrefundNotPaid() public {
+        // deploy the counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        // Let's send a transaction to the counter contract through our wallet
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
+        // send a transaction to the counter contract through our wallet
+        // without a paymaster and without prefunding the wallet
         UserOperation memory userOp = this.createUserOperation(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(counter),
             0,
@@ -150,28 +197,63 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        vm.expectRevert(abi.encodeWithSignature("FailedOp(uint256,string)", 0, "AA21 didn't pay prefund"));
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(counter.count(), 1);
-        vm.stopPrank();
     }
 
-    function testFailTransactionViaPaymasterNoapproval() public {
-        vm.startPrank(_owner);
-        // Let's deploy the counter contract
+    function test_RevertWhen_SendingTransactionDirectlyAndPrefund() public {
+        // deploy the counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        vm.stopPrank();
-        _setPaymasterForContract(address(counter));
-        vm.startPrank(_owner);
-        // Let's send a transaction to the counter contract through our wallet
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
+        // sender prefunds the contract
+        vm.deal(address(_kintoWalletv1), 1 ether);
+        vm.prank(address(_kintoWalletv1));
+        payable(address(counter)).call{value: 1 ether}("");
+
+        UserOperation[] memory userOps = new UserOperation[](2);
+
+        // whitelist app
+        userOps[0] = createWhitelistAppOp(
+            _chainID,
+            privateKeys,
+            address(_kintoWalletv1),
+            _kintoWalletv1.getNonce(),
+            address(counter),
+            address(_paymaster)
+        );
+
+        // send a transaction to the counter contract through our wallet
+        // without a paymaster but prefunding the wallet
+        userOps[1] = this.createUserOperation(
+            _chainID,
+            address(_kintoWalletv1),
+            _kintoWalletv1.getNonce() + 1,
+            privateKeys,
+            address(counter),
+            0,
+            abi.encodeWithSignature("increment()")
+        );
+
+        // execute the transaction via the entry point
+        _entryPoint.handleOps(userOps, payable(_owner));
+        assertEq(counter.count(), 1);
+    }
+
+    function test_RevertWhen_TransactionViaPaymasterAndNoApproval() public {
+        // deploy the counter contract
+        Counter counter = new Counter();
+        assertEq(counter.count(), 0);
+
+        _fundPaymasterForContract(address(counter));
+
+        // send a transaction to the counter contract through our wallet
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(counter),
             0,
@@ -180,11 +262,17 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
-        vm.expectRevert();
+
+        // execute the transaction via the entry point
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(counter.count(), 1);
-        vm.stopPrank();
+        assertEq(counter.count(), 0);
     }
 
     function testTransactionViaPaymaster() public {
@@ -193,18 +281,16 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
         vm.stopPrank();
-        _setPaymasterForContract(address(counter));
+        _fundPaymasterForContract(address(counter));
         vm.startPrank(_owner);
         // Let's send a transaction to the counter contract through our wallet
-        uint256 startingNonce = _kintoWalletv1.getNonce();
+        uint256 nonce = _kintoWalletv1.getNonce();
         bool[] memory flags = new bool[](1);
         flags[0] = true;
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
         UserOperation memory userOp2 = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(counter),
             0,
@@ -212,7 +298,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(_paymaster)
         );
         UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = createApprovalUserOp(
+        userOps[0] = createWhitelistAppOp(
             _chainID,
             privateKeys,
             address(_kintoWalletv1),
@@ -232,17 +318,15 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         // Let's deploy the counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         vm.stopPrank();
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        _fundPaymasterForContract(address(counter));
         // Let's send a transaction to the counter contract through our wallet
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(counter),
             0,
@@ -252,7 +336,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         UserOperation memory userOp2 = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 2,
+            nonce + 2,
             privateKeys,
             address(counter),
             0,
@@ -260,8 +344,8 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(_paymaster)
         );
         UserOperation[] memory userOps = new UserOperation[](3);
-        userOps[0] = createApprovalUserOp(
-            _chainID, privateKeys, address(_kintoWalletv1), startingNonce, address(counter), address(_paymaster)
+        userOps[0] = createWhitelistAppOp(
+            _chainID, privateKeys, address(_kintoWalletv1), nonce, address(counter), address(_paymaster)
         );
         userOps[1] = userOp;
         userOps[2] = userOp2;
@@ -276,12 +360,10 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         // Let's deploy the counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         vm.stopPrank();
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        _fundPaymasterForContract(address(counter));
         address[] memory targets = new address[](3);
         targets[0] = address(_kintoWalletv1);
         targets[1] = address(counter);
@@ -301,7 +383,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
         OperationParams memory opParams = OperationParams({targetContracts: targets, values: values, bytesOps: calls});
         UserOperation memory userOp = this.createUserOperationBatchWithPaymaster(
-            _chainID, address(_kintoWalletv1), startingNonce, privateKeys, opParams, address(_paymaster)
+            _chainID, address(_kintoWalletv1), nonce, privateKeys, opParams, address(_paymaster)
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
@@ -311,63 +393,65 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         vm.stopPrank();
     }
 
-    function testFailMultipleTransactionsExecuteBatchPaymasterRefuses() public {
-        vm.startPrank(_owner);
-        // Let's deploy the counter contract
+    function test_RevertWhen_MultipleTransactionsExecuteBatchPaymasterRefuses() public {
+        // deploy the counter contract
         Counter counter = new Counter();
         Counter counter2 = new Counter();
         assertEq(counter.count(), 0);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-        vm.stopPrank();
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        assertEq(counter2.count(), 0);
+
+        // only fund counter
+        _fundPaymasterForContract(address(counter));
+
+        // prep batch
         address[] memory targets = new address[](3);
         targets[0] = address(_kintoWalletv1);
         targets[1] = address(counter);
         targets[2] = address(counter2);
+
         uint256[] memory values = new uint256[](3);
         values[0] = 0;
         values[1] = 0;
         values[2] = 0;
-        bytes[] memory calls = new bytes[](3);
+
         address[] memory apps = new address[](1);
         apps[0] = address(counter);
+
         bool[] memory flags = new bool[](1);
         flags[0] = true;
+
+        // we want to do 3 calls: setAppWhitelist, increment counter and increment counter2
+        bytes[] memory calls = new bytes[](3);
         calls[0] = abi.encodeWithSignature("setAppWhitelist(address[],bool[])", apps, flags);
         calls[1] = abi.encodeWithSignature("increment()");
         calls[2] = abi.encodeWithSignature("increment()");
-        // Let's send both transactions via batch
+
+        // send all transactions via batch
         OperationParams memory opParams = OperationParams({targetContracts: targets, values: values, bytesOps: calls});
         UserOperation memory userOp = this.createUserOperationBatchWithPaymaster(
-            _chainID, address(_kintoWalletv1), startingNonce, privateKeys, opParams, address(_paymaster)
+            _chainID, address(_kintoWalletv1), _kintoWalletv1.getNonce(), privateKeys, opParams, address(_paymaster)
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        vm.expectRevert();
+        // todo: vm.expectRevert(abi.encodeWithSignature("FailedOpWithRevert(uint256,string,bytes)", 0, "AA33 reverted", "TODO"));
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(counter.count(), 1);
-        assertEq(counter2.count(), 1);
-        vm.stopPrank();
     }
 
     /* ============ Signers & Policy Tests ============ */
 
     function testAddingOneSigner() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -382,19 +466,15 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         vm.stopPrank();
     }
 
-    function testFailWithDuplicateSigner() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_DuplicateSigner() public {
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _owner;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -403,23 +483,26 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(1), _owner);
-        vm.stopPrank();
     }
 
-    function testFailWithEmptyArray() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_WithEmptyArray() public {
         address[] memory owners = new address[](0);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -428,27 +511,30 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(0), address(0));
-        vm.stopPrank();
     }
 
-    function testFailWithManyOwners() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+    function test_RevertWhen_WithManyOwners() public {
         address[] memory owners = new address[](4);
         owners[0] = _owner;
         owners[1] = _user;
         owners[2] = _user;
         owners[3] = _user;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -457,24 +543,27 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(3), _user);
-        vm.stopPrank();
     }
 
-    function testFailWithoutKYCSigner() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+    function test_RevertWhen_WithoutKYCSigner() public {
         address[] memory owners = new address[](1);
         owners[0] = _user;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -483,25 +572,21 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(1), _user);
-        vm.stopPrank();
     }
 
     function testChangingPolicyWithTwoSigners() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -519,18 +604,15 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
     function testChangingPolicyWithThreeSigners() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address[] memory owners = new address[](3);
         owners[0] = _owner;
         owners[1] = _user;
         owners[2] = _user2;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -547,60 +629,75 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         vm.stopPrank();
     }
 
-    function testFailChangingPolicyWithoutRightSigners() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_ChangingPolicyWithoutRightSigners() public {
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
+
+        uint256 nonce = _kintoWalletv1.getNonce();
+
+        // call setSignerPolicy with ALL_SIGNERS policy should revert because the wallet has 1 owners
+        // and the policy requires 3 owners.
+        UserOperation[] memory userOps = new UserOperation[](2);
+        userOps[0] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
-            privateKeys,
-            address(_kintoWalletv1),
-            0,
-            abi.encodeWithSignature("resetSigners(address[], uint8)", owners, _kintoWalletv1.signerPolicy()),
-            address(_paymaster)
-        );
-        UserOperation memory userOp2 = this.createUserOperationWithPaymaster(
-            _chainID,
-            address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
             abi.encodeWithSignature("setSignerPolicy(uint8)", _kintoWalletv1.ALL_SIGNERS()),
             address(_paymaster)
         );
-        UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = userOp2;
-        userOps[1] = userOp;
+
+        // call resetSigners with existing policy (SINGLE_SIGNER) should revert because I'm passing 2 owners
+        userOps[1] = this.createUserOperationWithPaymaster(
+            _chainID,
+            address(_kintoWalletv1),
+            nonce + 1,
+            privateKeys,
+            address(_kintoWalletv1),
+            0,
+            abi.encodeWithSignature("resetSigners(address[], uint8)", owners, _kintoWalletv1.signerPolicy()),
+            address(_paymaster)
+        );
+
+        // expect revert events for the 2 ops
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
+
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[1]),
+            userOps[1].sender,
+            userOps[1].nonce,
+            bytes("") // todo: add revert reason
+        );
+
         // Execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(1), _user);
-        assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.ALL_SIGNERS());
-        vm.stopPrank();
+        assertEq(_kintoWalletv1.owners(0), _owner);
+        assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.SINGLE_SIGNER());
     }
 
     /* ============ Multisig Transactions ============ */
 
     function testMultisigTransaction() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+        // (1). generate resetSigners UserOp to set 2 owners
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -609,23 +706,41 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // (2). execute the transaction via the entry point
+        vm.expectEmit();
+        emit WalletPolicyChanged(_kintoWalletv1.ALL_SIGNERS(), _kintoWalletv1.SINGLE_SIGNER());
         _entryPoint.handleOps(userOps, payable(_owner));
+
         assertEq(_kintoWalletv1.owners(1), _user);
         assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.ALL_SIGNERS());
-        // Deploy Counter contract
+
+        // (3). deploy Counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        vm.stopPrank();
-        // Fund counter contract
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
-        // Create counter increment transaction
-        userOps = new UserOperation[](2);
+
+        // (4). fund paymaster for Counter contract
+        _fundPaymasterForContract(address(counter));
+
+        // (5). Set private keys
         privateKeys = new uint256[](2);
-        privateKeys[0] = 1;
-        privateKeys[1] = 3;
-        userOp = this.createUserOperationWithPaymaster(
+        privateKeys[0] = _ownerPk;
+        privateKeys[1] = _userPk;
+
+        // (6). Create 2 user ops:
+        userOps = new UserOperation[](2);
+        // a. Approval UserOp
+        userOps[0] = createWhitelistAppOp(
+            _chainID,
+            privateKeys,
+            address(_kintoWalletv1),
+            _kintoWalletv1.getNonce(),
+            address(counter),
+            address(_paymaster)
+        );
+
+        // b. Counter increment
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
             _kintoWalletv1.getNonce() + 1,
@@ -635,33 +750,22 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             abi.encodeWithSignature("increment()"),
             address(_paymaster)
         );
-        userOps[0] = createApprovalUserOp(
-            _chainID,
-            privateKeys,
-            address(_kintoWalletv1),
-            _kintoWalletv1.getNonce(),
-            address(counter),
-            address(_paymaster)
-        );
-        userOps[1] = userOp;
+
+        // (7). execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(counter.count(), 1);
-        vm.stopPrank();
     }
 
-    function testFailMultisigTransaction() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_MultisigTransaction() public {
+        // (1). generate resetSigners UserOp to set 2 owners
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user;
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -670,22 +774,36 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
-        // Execute the transaction via the entry point
+
+        // (2). execute the transaction via the entry point
+        vm.expectEmit();
+        emit WalletPolicyChanged(_kintoWalletv1.ALL_SIGNERS(), _kintoWalletv1.SINGLE_SIGNER());
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(_kintoWalletv1.owners(1), _user);
         assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.ALL_SIGNERS());
-        // Deploy Counter contract
+
+        // (3). deploy Counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        vm.stopPrank();
-        // Fund counter contract
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
-        // Create counter increment transaction
+
+        // (4). fund paymaster for Counter contract
+        _fundPaymasterForContract(address(counter));
+
+        // (5). Create 2 user ops:
         userOps = new UserOperation[](2);
-        privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-        userOp = this.createUserOperationWithPaymaster(
+
+        // a. Approval UserOp
+        userOps[0] = createWhitelistAppOp(
+            _chainID,
+            privateKeys,
+            address(_kintoWalletv1),
+            _kintoWalletv1.getNonce(),
+            address(counter),
+            address(_paymaster)
+        );
+
+        // b. Counter increment
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
             _kintoWalletv1.getNonce() + 1,
@@ -695,42 +813,23 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             abi.encodeWithSignature("increment()"),
             address(_paymaster)
         );
-        userOps[0] = createApprovalUserOp(
-            _chainID,
-            privateKeys,
-            address(_kintoWalletv1),
-            _kintoWalletv1.getNonce(),
-            address(counter),
-            address(_paymaster)
-        );
-        userOps[1] = userOp;
 
+        // (7). execute the transaction via the entry point
+        vm.expectRevert(abi.encodeWithSignature("FailedOp(uint256,string)", 0, "AA24 signature error"));
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(counter.count(), 1);
-        vm.stopPrank();
     }
 
     function testMultisigTransactionWith3Signers() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-
-        // set 3 owners
+        // (1). generate resetSigners UserOp to set 3 owners
         address[] memory owners = new address[](3);
         owners[0] = _owner;
         owners[1] = _user;
         owners[2] = _user2;
 
-        // get nonce
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        // generate the user operation wihch changes the policy to ALL_SIGNERS
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -740,27 +839,31 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
 
-        // Execute the transaction via the entry point
+        // (2). execute the transaction via the entry point
+        vm.expectEmit();
+        emit WalletPolicyChanged(_kintoWalletv1.ALL_SIGNERS(), _kintoWalletv1.SINGLE_SIGNER());
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(_kintoWalletv1.owners(1), _user);
         assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.ALL_SIGNERS());
 
-        // Deploy Counter contract
+        // (3). deploy Counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
         vm.stopPrank();
 
-        // Fund counter contract
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        // (4). fund paymaster for Counter contract
+        _fundPaymasterForContract(address(counter));
 
-        // Create counter increment transaction
-        userOps = new UserOperation[](2);
+        // (5). Set private keys
         privateKeys = new uint256[](3);
-        privateKeys[0] = 1;
-        privateKeys[1] = 3;
-        privateKeys[2] = 5;
-        userOps[0] = createApprovalUserOp(
+        privateKeys[0] = _ownerPk;
+        privateKeys[1] = _userPk;
+        privateKeys[2] = _user2Pk;
+
+        // (6). Create 2 user ops:
+        userOps = new UserOperation[](2);
+        // a. Approval UserOp
+        userOps[0] = createWhitelistAppOp(
             _chainID,
             privateKeys,
             address(_kintoWalletv1),
@@ -768,7 +871,8 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(counter),
             address(_paymaster)
         );
-        userOp = this.createUserOperationWithPaymaster(
+        // b. Counter increment
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
             _kintoWalletv1.getNonce() + 1,
@@ -778,64 +882,25 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             abi.encodeWithSignature("increment()"),
             address(_paymaster)
         );
-        userOps[1] = userOp;
 
-        // execute
+        // (7). execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(counter.count(), 1);
-        vm.stopPrank();
     }
 
     function testMultisigTransactionWith1SignerButSeveralOwners() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-
-        // set 3 owners
-        address[] memory owners = new address[](3);
-        owners[0] = _owner;
-        owners[1] = _user;
-        owners[2] = _user2;
-
-        // get nonce
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        // generate the user operation wihch changes the policy to ALL_SIGNERS
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
-            _chainID,
-            address(_kintoWalletv1),
-            startingNonce,
-            privateKeys,
-            address(_kintoWalletv1),
-            0,
-            abi.encodeWithSignature("resetSigners(address[],uint8)", owners, _kintoWalletv1.SINGLE_SIGNER()),
-            address(_paymaster)
-        );
-        UserOperation[] memory userOps = new UserOperation[](1);
-        userOps[0] = userOp;
-
-        // Execute the transaction via the entry point
-        _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.owners(1), _user);
-        assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.SINGLE_SIGNER());
-
-        // Deploy Counter contract
+        // (1). deploy Counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        vm.stopPrank();
 
-        // Fund counter contract
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        // (2). fund paymaster for Counter contract
+        _fundPaymasterForContract(address(counter));
 
-        // Create counter increment transaction
+        // (3). Create 2 user ops:
+        UserOperation[] memory userOps = new UserOperation[](1);
         userOps = new UserOperation[](2);
-        privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        userOps[0] = createApprovalUserOp(
+        // a. Approval UserOp
+        userOps[0] = createWhitelistAppOp(
             _chainID,
             privateKeys,
             address(_kintoWalletv1),
@@ -844,7 +909,8 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(_paymaster)
         );
 
-        userOp = this.createUserOperationWithPaymaster(
+        // b. Counter increment
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
             _kintoWalletv1.getNonce() + 1,
@@ -854,35 +920,24 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             abi.encodeWithSignature("increment()"),
             address(_paymaster)
         );
-        userOps[1] = userOp;
 
-        // execute
+        // (4). execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(counter.count(), 1);
         vm.stopPrank();
     }
 
-    function testFailMultisigTransactionWhen2OutOf3Signers() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-
-        // set 3 owners
+    function test_RevertWhen_MultisigTransactionHas2OutOf3Signers() public {
+        // (1). generate resetSigners UserOp to set 3 owners
         address[] memory owners = new address[](3);
         owners[0] = _owner;
         owners[1] = _user;
         owners[2] = _user2;
 
-        // get nonce
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        // generate the user operation wihch changes the policy to ALL_SIGNERS
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -892,27 +947,31 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
 
-        // Execute the transaction via the entry point
+        // (2). execute the transaction via the entry point
+        vm.expectEmit();
+        emit WalletPolicyChanged(_kintoWalletv1.ALL_SIGNERS(), _kintoWalletv1.SINGLE_SIGNER());
         _entryPoint.handleOps(userOps, payable(_owner));
+
         assertEq(_kintoWalletv1.owners(1), _user);
         assertEq(_kintoWalletv1.signerPolicy(), _kintoWalletv1.ALL_SIGNERS());
 
-        // Deploy Counter contract
+        // (3). deploy Counter contract
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
-        vm.stopPrank();
 
-        // Fund counter contract
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        // (4). fund paymaster for Counter contract
+        _fundPaymasterForContract(address(counter));
 
-        // Create counter increment transaction
-        userOps = new UserOperation[](2);
+        // (5). Set private keys
         privateKeys = new uint256[](2);
-        privateKeys[0] = 1;
-        privateKeys[1] = 3;
+        privateKeys[0] = _ownerPk;
+        privateKeys[1] = _userPk;
 
-        userOps[0] = createApprovalUserOp(
+        // (6). Create 2 user ops:
+        userOps = new UserOperation[](2);
+
+        // a. Approval UserOp
+        userOps[0] = createWhitelistAppOp(
             _chainID,
             privateKeys,
             address(_kintoWalletv1),
@@ -920,7 +979,9 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(counter),
             address(_paymaster)
         );
-        userOp = this.createUserOperationWithPaymaster(
+
+        // b. Counter increment
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
             _kintoWalletv1.getNonce() + 1,
@@ -930,24 +991,19 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             abi.encodeWithSignature("increment()"),
             address(_paymaster)
         );
-        userOps[0] = userOp;
 
-        // execute
+        // (7). execute the transaction via the entry point
+        vm.expectRevert(abi.encodeWithSignature("FailedOp(uint256,string)", 0, "AA24 signature error"));
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(counter.count(), 1);
-        vm.stopPrank();
     }
 
     /* ============ Recovery Process ============ */
 
     function testRecoverAccountSuccessfully() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.stopPrank();
         vm.startPrank(_recoverer);
         assertEq(_kintoWalletv1.owners(0), _owner);
 
-        // Start Recovery
+        // start Recovery
         _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
         assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
         vm.stopPrank();
@@ -962,6 +1018,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         vm.stopPrank();
         vm.startPrank(_owner);
         assertEq(_kintoIDv1.isKYC(_user), true);
+
         // Pass recovery time
         vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() + 1);
         address[] memory users = new address[](1);
@@ -978,114 +1035,109 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         assertEq(_kintoWalletv1.owners(0), _user);
     }
 
-    function testFailRecoverNotRecoverer() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        assertEq(_kintoWalletv1.owners(0), _owner);
-
-        // Start Recovery
+    function test_RevertWhen_RecoverNotRecoverer(address someone) public {
+        vm.assume(someone != _kintoWalletv1.recoverer());
+        // start recovery
+        vm.expectRevert("only recoverer");
         _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
     }
 
-    function testFailDirectCall() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_recoverer);
-
-        // Start Recovery
+    function test_RevertWhen_DirectCall() public {
+        vm.prank(_recoverer);
+        vm.expectRevert("KW: only factory");
         _kintoWalletv1.startRecovery();
     }
 
-    function testFailRecoverWithoutBurningOldOwner() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_recoverer);
+    function test_RevertWhen_RecoverWithoutBurningOldOwner() public {
         assertEq(_kintoWalletv1.owners(0), _owner);
 
-        // Start Recovery
-        _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
-        assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
-        vm.stopPrank();
-
-        // Mint NFT to new owner
-        IKintoID.SignatureData memory sigdata = _auxCreateSignature(_kintoIDv1, _user, _user, 3, block.timestamp + 1000);
-        uint8[] memory traits = new uint8[](0);
-        vm.startPrank(_kycProvider);
-        _kintoIDv1.mintIndividualKyc(sigdata, traits);
-        vm.stopPrank();
-        vm.startPrank(_owner);
-        assertEq(_kintoIDv1.isKYC(_user), true);
-        // Pass recovery time
-        vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() + 1);
-        // Monitor AML
-        address[] memory users = new address[](1);
-        users[0] = _user;
-        IKintoID.MonitorUpdateData[][] memory updates = new IKintoID.MonitorUpdateData[][](1);
-        updates[0] = new IKintoID.MonitorUpdateData[](1);
-        updates[0][0] = IKintoID.MonitorUpdateData(true, true, 5);
-        vm.prank(_kycProvider);
-        _kintoIDv1.monitor(users, updates);
+        // start recovery
         vm.prank(_recoverer);
-        _walletFactory.completeWalletRecovery(payable(address(_kintoWalletv1)), users);
-    }
-
-    function testFailRecoverWithoutMintingNewOwner() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_recoverer);
-        assertEq(_kintoWalletv1.owners(0), _owner);
-
-        // Start Recovery
         _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
         assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
-        vm.stopPrank();
 
-        // Burn old owner NFT
-        vm.startPrank(_kycProvider);
-        IKintoID.SignatureData memory sigdata =
-            _auxCreateSignature(_kintoIDv1, _owner, _owner, 1, block.timestamp + 1000);
-        _kintoIDv1.burnKYC(sigdata);
-        vm.stopPrank();
-        vm.startPrank(_owner);
+        // approve KYC for _user (mint NFT)
+        approveKYC(_user, _userPk);
         assertEq(_kintoIDv1.isKYC(_user), true);
-        // Pass recovery time
+
+        // pass recovery time
         vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() + 1);
-        address[] memory users = new address[](1);
-        users[0] = _user;
-        _walletFactory.completeWalletRecovery(payable(address(_kintoWalletv1)), users);
-    }
 
-    function testFailRecoverNotEnoughTime() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
-        vm.startPrank(_recoverer);
-        assertEq(_kintoWalletv1.owners(0), _owner);
-
-        // Start Recovery
-        _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
-        assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
-        vm.stopPrank();
-
-        // Mint NFT to new owner and burn old
-        IKintoID.SignatureData memory sigdata = _auxCreateSignature(_kintoIDv1, _user, _user, 3, block.timestamp + 1000);
-        uint8[] memory traits = new uint8[](0);
-        vm.startPrank(_kycProvider);
-        _kintoIDv1.mintIndividualKyc(sigdata, traits);
-        sigdata = _auxCreateSignature(_kintoIDv1, _owner, _owner, 1, block.timestamp + 1000);
-        _kintoIDv1.burnKYC(sigdata);
-        vm.stopPrank();
-        vm.startPrank(_owner);
-        assertEq(_kintoIDv1.isKYC(_user), true);
-        // Pass recovery time (not enough)
-        vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() - 1);
-        address[] memory users = new address[](1);
-        users[0] = _user;
+        // monitor AML
         IKintoID.MonitorUpdateData[][] memory updates = new IKintoID.MonitorUpdateData[][](1);
         updates[0] = new IKintoID.MonitorUpdateData[](1);
         updates[0][0] = IKintoID.MonitorUpdateData(true, true, 5);
+
+        address[] memory users = new address[](1);
+        users[0] = _user;
+
         vm.prank(_kycProvider);
         _kintoIDv1.monitor(users, updates);
-        vm.prank(_owner);
+
+        // complete recovery
+        vm.prank(_recoverer);
+        vm.expectRevert("KW-fr: Old KYC must be burned");
+        _walletFactory.completeWalletRecovery(payable(address(_kintoWalletv1)), users);
+    }
+
+    function test_RevertWhen_RecoverWithoutNewOwnerKYCd() public {
+        assertEq(_kintoWalletv1.owners(0), _owner);
+
+        // start Recovery
+        vm.prank(_recoverer);
+        _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
+        assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
+
+        // burn old owner NFT
+        revokeKYC(_owner, _ownerPk);
+        assertEq(_kintoIDv1.isKYC(_owner), false);
+
+        // pass recovery time
+        vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() + 1);
+
+        // complete recovery
+        assertEq(_kintoIDv1.isKYC(_user), false); // new owner is not KYC'd
+        address[] memory users = new address[](1);
+        users[0] = _user;
+        vm.prank(_recoverer);
+        vm.expectRevert("KW-rs: KYC Required");
+        _walletFactory.completeWalletRecovery(payable(address(_kintoWalletv1)), users);
+    }
+
+    function test_RevertWhen_RecoverNotEnoughTime() public {
+        assertEq(_kintoWalletv1.owners(0), _owner);
+
+        // start Recovery
+        vm.prank(_recoverer);
+        _walletFactory.startWalletRecovery(payable(address(_kintoWalletv1)));
+        assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
+
+        // burn old owner NFT
+        revokeKYC(_owner, _ownerPk);
+        assertEq(_kintoIDv1.isKYC(_owner), false);
+
+        // approve KYC for _user (mint NFT)
+        approveKYC(_user, _userPk);
+        assertEq(_kintoIDv1.isKYC(_user), true);
+
+        // pass recovery time (not enough)
+        vm.warp(block.timestamp + _kintoWalletv1.RECOVERY_TIME() - 1);
+
+        // monitor AML
+        IKintoID.MonitorUpdateData[][] memory updates = new IKintoID.MonitorUpdateData[][](1);
+        updates[0] = new IKintoID.MonitorUpdateData[](1);
+        updates[0][0] = IKintoID.MonitorUpdateData(true, true, 5);
+
+        address[] memory users = new address[](1);
+        users[0] = _user;
+
+        vm.prank(_kycProvider);
+        _kintoIDv1.monitor(users, updates);
+
+        // complete recovery
+        vm.prank(_recoverer);
+
+        vm.expectRevert("KW-fr: too early");
         _walletFactory.completeWalletRecovery(payable(address(_kintoWalletv1)), users);
     }
 
@@ -1101,18 +1153,15 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
     function testAddingOneFunder() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address[] memory funders = new address[](1);
         funders[0] = address(23);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
         bool[] memory flags = new bool[](1);
         flags[0] = true;
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            nonce,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -1130,89 +1179,80 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
     /* ============ Token Approvals ============ */
 
     function testApproveTokens() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address app = address(100);
         address[] memory tokens = new address[](1);
         tokens[0] = address(_engenCredits);
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1e12;
 
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
+        uint256 nonce = _kintoWalletv1.getNonce();
+        UserOperation[] memory userOps = new UserOperation[](2);
+        userOps[0] = createWhitelistAppOp(
+            _chainID, privateKeys, address(_kintoWalletv1), nonce, address(app), address(_paymaster)
+        );
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(_kintoWalletv1),
             0,
             abi.encodeWithSignature("approveTokens(address,address[],uint256[])", app, tokens, amounts),
             address(_paymaster)
         );
-        UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = createApprovalUserOp(
-            _chainID, privateKeys, address(_kintoWalletv1), _kintoWalletv1.getNonce(), address(app), address(_paymaster)
-        );
-        userOps[1] = userOp;
 
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(_kintoWalletv1.isTokenApproved(app, tokens[0]), 1e12);
         assertEq(_kintoWalletv1.isTokenApproved(app, address(24)), 0);
-        vm.stopPrank();
     }
 
-    function testFailApproveTokensWithoutWhitelist() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_ApproveTokensWithoutWhitelist() public {
         address app = address(100);
         address[] memory tokens = new address[](1);
         tokens[0] = address(_engenCredits);
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1e12;
 
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
+        UserOperation[] memory userOps = new UserOperation[](1);
+        userOps[0] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
             abi.encodeWithSignature("approveTokens(address,address[],uint256[])", app, tokens, amounts),
             address(_paymaster)
         );
-        UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = userOp;
 
+        // execute the transaction via the entry point and expect a revert event
+        uint256 tokenApprovalBefore = _kintoWalletv1.isTokenApproved(app, tokens[0]);
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.isTokenApproved(app, tokens[0]), 1e12);
-        assertEq(_kintoWalletv1.isTokenApproved(app, address(24)), 0);
-        vm.stopPrank();
+        assertEq(_kintoWalletv1.isTokenApproved(app, tokens[0]), tokenApprovalBefore);
     }
 
     function testApproveAndRevokeTokens() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address app = address(100);
         address[] memory tokens = new address[](1);
         tokens[0] = address(_engenCredits);
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 1e12;
 
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
+        uint256 nonce = _kintoWalletv1.getNonce();
 
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -1220,7 +1260,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
             address(_paymaster)
         );
         UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = createApprovalUserOp(
+        userOps[0] = createWhitelistAppOp(
             _chainID, privateKeys, address(_kintoWalletv1), _kintoWalletv1.getNonce(), address(app), address(_paymaster)
         );
         userOps[1] = userOp;
@@ -1246,54 +1286,48 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         vm.stopPrank();
     }
 
-    function testFailCallingApproveDirectly() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_engenCredits));
+    function test_RevertWhen_CallingApproveDirectly() public {
+        _fundPaymasterForContract(address(_engenCredits));
         address app = address(100);
 
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
+        uint256 nonce = _kintoWalletv1.getNonce();
+        UserOperation[] memory userOps = new UserOperation[](2);
+        userOps[0] = createWhitelistAppOp(
+            _chainID, privateKeys, address(_kintoWalletv1), nonce, address(_engenCredits), address(_paymaster)
+        );
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(_engenCredits),
             0,
             abi.encodeWithSignature("approve(address,uint256)", address(app), 1e12),
             address(_paymaster)
         );
-        UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = createApprovalUserOp(
-            _chainID,
-            privateKeys,
-            address(_kintoWalletv1),
-            _kintoWalletv1.getNonce(),
-            address(_engenCredits),
-            address(_paymaster)
-        );
-        userOps[1] = userOp;
 
+        // execute the transaction via the entry point and expect a revert event
+        uint256 allowanceBefore = _engenCredits.allowance(address(_kintoWalletv1), app);
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[1]),
+            userOps[1].sender,
+            userOps[1].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_engenCredits.allowance(address(_kintoWalletv1), app), 1e12);
-        vm.stopPrank();
+        assertEq(_engenCredits.allowance(address(_kintoWalletv1), app), allowanceBefore);
     }
 
     /* ============ App Key ============ */
 
-    function testFailSettingAppKeyNoWhitelist() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+    function test_RevertWhen_SettingAppKeyNoWhitelist() public {
         address app = address(_engenCredits);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -1302,65 +1336,59 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         );
         UserOperation[] memory userOps = new UserOperation[](1);
         userOps[0] = userOp;
+
         // Execute the transaction via the entry point
+        address appSignerBefore = _kintoWalletv1.appSigner(app);
+        // @dev handleOps fails silently (does not revert)
+        vm.expectEmit(true, true, true, false);
+        emit UserOperationRevertReason(
+            _entryPoint.getUserOpHash(userOps[0]),
+            userOps[0].sender,
+            userOps[0].nonce,
+            bytes("") // todo: add revert reason
+        );
         _entryPoint.handleOps(userOps, payable(_owner));
-        assertEq(_kintoWalletv1.appSigner(app), _user);
-        vm.stopPrank();
+        assertEq(_kintoWalletv1.appSigner(app), appSignerBefore);
     }
 
     function testSettingAppKey() public {
-        vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
         address app = address(_engenCredits);
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-        UserOperation memory userOp = this.createUserOperationWithPaymaster(
+        uint256 nonce = _kintoWalletv1.getNonce();
+
+        UserOperation[] memory userOps = new UserOperation[](2);
+        userOps[0] = createWhitelistAppOp(
+            _chainID, privateKeys, address(_kintoWalletv1), nonce, address(_engenCredits), address(_paymaster)
+        );
+
+        userOps[1] = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce + 1,
+            nonce + 1,
             privateKeys,
             address(_kintoWalletv1),
             0,
             abi.encodeWithSignature("setAppKey(address,address)", app, _user),
             address(_paymaster)
         );
-        UserOperation[] memory userOps = new UserOperation[](2);
-        userOps[0] = createApprovalUserOp(
-            _chainID,
-            privateKeys,
-            address(_kintoWalletv1),
-            _kintoWalletv1.getNonce(),
-            address(_engenCredits),
-            address(_paymaster)
-        );
-        userOps[1] = userOp;
+
         // Execute the transaction via the entry point
         _entryPoint.handleOps(userOps, payable(_owner));
         assertEq(_kintoWalletv1.appSigner(app), _user);
-        vm.stopPrank();
     }
 
     function testMultisigTransactionWith2SignersWithAppkey() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
 
         // set 2 owners
         address[] memory owners = new address[](2);
         owners[0] = _owner;
         owners[1] = _user2;
 
-        // get nonce
-        uint256 startingNonce = _kintoWalletv1.getNonce();
-
-        uint256[] memory privateKeys = new uint256[](1);
-        privateKeys[0] = 1;
-
         // generate the user operation wihch changes the policy to ALL_SIGNERS
         UserOperation memory userOp = this.createUserOperationWithPaymaster(
             _chainID,
             address(_kintoWalletv1),
-            startingNonce,
+            _kintoWalletv1.getNonce(),
             privateKeys,
             address(_kintoWalletv1),
             0,
@@ -1382,14 +1410,14 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
         // Fund counter contract
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(counter));
+        _fundPaymasterForContract(address(counter));
 
         // Create counter increment transaction
         userOps = new UserOperation[](2);
         privateKeys = new uint256[](2);
-        privateKeys[0] = 1;
-        privateKeys[1] = 5;
-        userOps[0] = createApprovalUserOp(
+        privateKeys[0] = _ownerPk;
+        privateKeys[1] = _user2Pk;
+        userOps[0] = createWhitelistAppOp(
             _chainID,
             privateKeys,
             address(_kintoWalletv1),

--- a/test/KintoWallet.t.sol
+++ b/test/KintoWallet.t.sol
@@ -53,24 +53,6 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
     uint256 _chainID = 1;
 
-    // private keys
-    uint256 _ownerPk = 1;
-    uint256 _secondownerPk = 2;
-    uint256 _userPk = 3;
-    uint256 _user2Pk = 4;
-    uint256 _upgraderPk = 5;
-    uint256 _kycProviderPk = 6;
-    uint256 _recovererPk = 7;
-
-    // users
-    address payable _owner = payable(vm.addr(_ownerPk));
-    address payable _secondowner = payable(vm.addr(_secondownerPk));
-    address payable _user = payable(vm.addr(_userPk));
-    address payable _user2 = payable(vm.addr(_user2Pk));
-    address payable _upgrader = payable(vm.addr(_upgraderPk));
-    address payable _kycProvider = payable(vm.addr(_kycProviderPk));
-    address payable _recoverer = payable(vm.addr(_recovererPk));
-
     // events
     event UserOperationRevertReason(
         bytes32 indexed userOpHash, address indexed sender, uint256 nonce, bytes revertReason
@@ -138,7 +120,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
 
     function test_RevertWhen_OthersCannotUpgrade() public {
         // create a wallet for _user
-        approveKYC(_user, _userPk);
+        approveKYC(_kycProvider, _user, _userPk);
         IKintoWallet userWallet = _walletFactory.createAccount(_user, _recoverer, 0);
 
         // deploy a KintoWalletv2
@@ -1057,7 +1039,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
 
         // approve KYC for _user (mint NFT)
-        approveKYC(_user, _userPk);
+        approveKYC(_kycProvider, _user, _userPk);
         assertEq(_kintoIDv1.isKYC(_user), true);
 
         // pass recovery time
@@ -1089,7 +1071,7 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
 
         // burn old owner NFT
-        revokeKYC(_owner, _ownerPk);
+        revokeKYC(_kycProvider, _owner, _ownerPk);
         assertEq(_kintoIDv1.isKYC(_owner), false);
 
         // pass recovery time
@@ -1113,11 +1095,11 @@ contract KintoWalletTest is AATestScaffolding, UserOp {
         assertEq(_kintoWalletv1.inRecovery(), block.timestamp);
 
         // burn old owner NFT
-        revokeKYC(_owner, _ownerPk);
+        revokeKYC(_kycProvider, _owner, _ownerPk);
         assertEq(_kintoIDv1.isKYC(_owner), false);
 
         // approve KYC for _user (mint NFT)
-        approveKYC(_user, _userPk);
+        approveKYC(_kycProvider, _user, _userPk);
         assertEq(_kintoIDv1.isKYC(_user), true);
 
         // pass recovery time (not enough)

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -60,21 +60,12 @@ contract KintoWalletFactoryTest is Create2Helper, UserOp, AATestScaffolding {
 
     uint256 _chainID = 1;
 
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address payable _user = payable(vm.addr(3));
-    address _user2 = address(4);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
-    address payable _funder = payable(vm.addr(8));
-
     function setUp() public {
         vm.chainId(_chainID);
         vm.startPrank(address(1));
         _owner.transfer(1e18);
         vm.stopPrank();
-        deployAAScaffolding(_owner, _kycProvider, _recoverer);
+        deployAAScaffolding(_owner, 1, _kycProvider, _recoverer);
     }
 
     function testUp() public {
@@ -94,7 +85,7 @@ contract KintoWalletFactoryTest is Create2Helper, UserOp, AATestScaffolding {
         vm.stopPrank();
     }
 
-    function testFailOthersCannotUpgradeFactory() public {
+    function test_RevertWhen_OthersCannotUpgradeFactory() public {
         KintoWalletFactoryV2 _implementationV2 = new KintoWalletFactoryV2(_kintoWalletImpl);
         _walletFactory.upgradeTo(address(_implementationV2));
         // re-wrap the _proxy
@@ -119,7 +110,7 @@ contract KintoWalletFactoryTest is Create2Helper, UserOp, AATestScaffolding {
         vm.stopPrank();
     }
 
-    function testFailOthersCannotUpgradeWallets() public {
+    function test_RevertWhen_OthersCannotUpgradeWallets() public {
         // Deploy wallet implementation
         _kintoWalletImpl = new KintoWalletV999(_entryPoint, _kintoIDv1);
         // deploy walletv1 through wallet factory and initializes it
@@ -142,7 +133,7 @@ contract KintoWalletFactoryTest is Create2Helper, UserOp, AATestScaffolding {
         vm.stopPrank();
     }
 
-    function testFailCreateWalletThroughDeploy() public {
+    function test_RevertWhen_CreateWalletThroughDeploy() public {
         vm.startPrank(_owner);
         bytes memory a = abi.encodeWithSelector(KintoWallet.initialize.selector, _owner, _owner);
         _walletFactory.deployContract(
@@ -162,7 +153,7 @@ contract KintoWalletFactoryTest is Create2Helper, UserOp, AATestScaffolding {
 
     function testWhitelistedSignerCanFundWallet() public {
         vm.startPrank(_owner);
-        _setPaymasterForContract(address(_kintoWalletv1));
+        _fundPaymasterForContract(address(_kintoWalletv1));
         uint256 startingNonce = _kintoWalletv1.getNonce();
         address[] memory funders = new address[](1);
         funders[0] = _funder;

--- a/test/SponsorPaymastExploit.t.sol
+++ b/test/SponsorPaymastExploit.t.sol
@@ -32,7 +32,7 @@ contract MyOpCreator is UserOp, KYCSignature {
         uint256 value,
         bytes calldata _bytesOp,
         address _paymaster
-    ) public view returns (UserOperation memory op) {
+    ) public returns (UserOperation memory op) {
         op = UserOperation({
             sender: _account,
             nonce: nonce,
@@ -82,14 +82,6 @@ contract SponsorPaymasterExploitTest is MyOpCreator {
     UpgradeableBeacon _beacon;
 
     uint256 _chainID = 1;
-
-    address payable _owner = payable(vm.addr(1));
-    address _secondowner = address(2);
-    address _user = vm.addr(3);
-    address _user2 = address(4);
-    address _upgrader = address(5);
-    address _kycProvider = address(6);
-    address _recoverer = address(7);
 
     function setUp() public {
         vm.chainId(_chainID);
@@ -145,7 +137,7 @@ contract SponsorPaymasterExploitTest is MyOpCreator {
         Counter counter = new Counter();
         assertEq(counter.count(), 0);
         vm.stopPrank();
-        _setPaymasterForContract(address(counter));
+        _fundPaymasterForContract(address(counter));
         vm.startPrank(_owner);
         // Let's send a transaction to the counter contract through our wallet
         uint256 startingNonce = _kintoWalletv1.getNonce();
@@ -176,7 +168,8 @@ contract SponsorPaymasterExploitTest is MyOpCreator {
         vm.stopPrank();
     }
 
-    function _setPaymasterForContract(address _contract) private {
+    // funds contract so paymaster can use to pay for gas
+    function _fundPaymasterForContract(address _contract) private {
         vm.startPrank(_owner);
         vm.deal(_owner, 1000e18);
         // We add the deposit to the counter contract in the paymaster

--- a/test/helpers/UserOp.sol
+++ b/test/helpers/UserOp.sol
@@ -19,6 +19,26 @@ import "forge-std/console.sol";
 abstract contract UserOp is Test {
     using ECDSAUpgradeable for bytes32;
 
+    // private keys
+    uint256 _ownerPk = 1;
+    uint256 _secondownerPk = 2;
+    uint256 _userPk = 3;
+    uint256 _user2Pk = 4;
+    uint256 _upgraderPk = 5;
+    uint256 _kycProviderPk = 6;
+    uint256 _recovererPk = 7;
+    uint256 _funderPk = 8;
+
+    // users
+    address payable _owner = payable(vm.addr(_ownerPk));
+    address payable _secondowner = payable(vm.addr(_secondownerPk));
+    address payable _user = payable(vm.addr(_userPk));
+    address payable _user2 = payable(vm.addr(_user2Pk));
+    address payable _upgrader = payable(vm.addr(_upgraderPk));
+    address payable _kycProvider = payable(vm.addr(_kycProviderPk));
+    address payable _recoverer = payable(vm.addr(_recovererPk));
+    address payable _funder = payable(vm.addr(_funderPk));
+
     struct OperationParams {
         address[] targetContracts;
         uint256[] values;

--- a/test/helpers/UserOp.sol
+++ b/test/helpers/UserOp.sol
@@ -164,7 +164,6 @@ abstract contract UserOp is Test {
         address _paymaster
     ) public view returns (UserOperation memory op) {
         op = _prepareUserOperation(_account, nonce, opParams, _paymaster);
-
         op.signature = _signUserOp(op, KintoWallet(payable(_account)).entryPoint(), _chainID, _privateKeyOwners);
     }
 
@@ -192,7 +191,7 @@ abstract contract UserOp is Test {
         return op;
     }
 
-    function createApprovalUserOp(
+    function createWhitelistAppOp(
         uint256 _chainId,
         uint256[] memory pk,
         address wallet,


### PR DESCRIPTION
- Refactors all `testFail*` tests to use `expectRevert()` or `expectEmit()` in the case of the tests that expect the `UserOperationRevertReason` event to be emitted.
- Also changed some test function method names
- Fixed very minor typos
- Added some helpers
 