### PR TITLE
Removes deploy contract by wallet

### DIFF
--- a/src/interfaces/IKintoWalletFactory.sol
+++ b/src/interfaces/IKintoWalletFactory.sol
@@ -19,11 +19,6 @@ interface IKintoWalletFactory {
         payable
         returns (address);
 
-    function deployContractByWallet(uint256 amount, bytes memory bytecode, bytes32 salt)
-        external
-        payable
-        returns (address);
-
     function startWalletRecovery(address payable wallet) external;
 
     function completeWalletRecovery(address payable wallet, address[] calldata newSigners) external;

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -178,25 +178,6 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     }
 
     /**
-     * @dev Deploys a contract using `CREATE2`. The address where the contract
-     * will be deployed can be known in advance via {computeAddress}.
-     *
-     * Same as above but this one goes through the Kinto Wallet.
-     * @param amount The amount of wei to send with the contract creation
-     * @param bytecode The bytecode of the contract to deploy
-     * @param salt The salt to use for the calculation
-     */
-    function deployContractByWallet(uint256 amount, bytes calldata bytecode, bytes32 salt)
-        external
-        payable
-        override
-        returns (address)
-    {
-        require(walletTs[msg.sender] > 0 && kintoID.isKYC(KintoWallet(payable(msg.sender)).owners(0)), "KYC required");
-        return _deployAndAssignOwnership(msg.sender, amount, bytecode, salt);
-    }
-
-    /**
      * @dev Fund a wallet through the factory given chain restrictions
      * @param wallet The wallet address to send eth to
      */


### PR DESCRIPTION
- It makes sense to keep only the one that allows EOA to deploy. The other can happen through normal userOp