### PR TITLE
Send money to account check

### DIFF
--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -202,10 +202,13 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
      * @param target The target address
      */
     function sendMoneyToAccount(address target) external payable override {
-        bool isPrivileged = owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
+        bool isPrivileged =
+            owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
         require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");
         bool isContract = target.code.length > 0;
-        require(target != address(0) && ((kintoID.isKYC(target) || isContract) || isPrivileged), "Invalid target address");
+        require(
+            target != address(0) && ((kintoID.isKYC(target) || isContract) || isPrivileged), "Invalid target address"
+        );
         (bool sent,) = target.call{value: msg.value}("");
         require(sent, "Failed to send Ether");
     }

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -198,15 +198,14 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
     }
 
     /**
-     * @dev Send money to an account from privileged accounts
+     * @dev Send money to an account from privileged accounts or from kyc accounts to kyc accounts or contracts.
      * @param target The target address
      */
     function sendMoneyToAccount(address target) external payable override {
-        require(
-            owner() == msg.sender || kintoID.isKYC(msg.sender)
-                || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender),
-            "KYC or Provider role required"
-        );
+        bool isPrivileged = owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
+        require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");
+        bool isContract = target.code.length > 0;
+        require(target != address(0) && ((kintoID.isKYC(target) || isContract) || isPrivileged), "Invalid target address");
         (bool sent,) = target.call{value: msg.value}("");
         require(sent, "Failed to send Ether");
     }

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -202,14 +202,12 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
      * @param target The target address
      */
     function sendMoneyToAccount(address target) external payable override {
-       require(target != address(0), "Invalid target: zero address");
+        require(target != address(0), "Invalid target: zero address");
         bool isPrivileged =
             owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
         require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");
         bool isValidTarget = kintoID.isKYC(target) || target.code.length > 0;
-        require(
-      require(isValidTarget || isPrivileged, "Target is not valid");
-        );
+        require(isValidTarget || isPrivileged, "Target is not valid");
         (bool sent,) = target.call{value: msg.value}("");
         require(sent, "Failed to send Ether");
     }

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -205,7 +205,7 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         bool isPrivileged =
             owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
         require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");
-        bool isContract = target.code.length > 0;
+        bool isValidTarget = kintoID.isKYC(target) || target.code.length > 0;
         require(
             target != address(0) && ((kintoID.isKYC(target) || isContract) || isPrivileged), "Invalid target address"
         );

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -207,7 +207,7 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
         require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");
         bool isValidTarget = kintoID.isKYC(target) || target.code.length > 0;
         require(
-            target != address(0) && ((kintoID.isKYC(target) || isContract) || isPrivileged), "Invalid target address"
+      require(isValidTarget || isPrivileged, "Target is not valid");
         );
         (bool sent,) = target.call{value: msg.value}("");
         require(sent, "Failed to send Ether");

--- a/src/wallet/KintoWalletFactory.sol
+++ b/src/wallet/KintoWalletFactory.sol
@@ -202,6 +202,7 @@ contract KintoWalletFactory is Initializable, UUPSUpgradeable, OwnableUpgradeabl
      * @param target The target address
      */
     function sendMoneyToAccount(address target) external payable override {
+       require(target != address(0), "Invalid target: zero address");
         bool isPrivileged =
             owner() == msg.sender || IAccessControl(address(kintoID)).hasRole(kintoID.KYC_PROVIDER_ROLE(), msg.sender);
         require(isPrivileged || kintoID.isKYC(msg.sender), "KYC or Provider role required");

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -371,7 +371,7 @@ contract KintoWalletFactoryTest is SharedSetup {
         assertEq(address(123).balance, 1e18);
     }
 
-    function testSendMoneyToAccount_When_CallerKYCAndTargetContract() public {
+    function testSendMoneyToAccount_WhenCallerIsKYCd_WhenTargetIsContract() public {
         vm.deal(_kycProvider, 1 ether);
         vm.prank(_kycProvider);
         uint256 beforeBalance = address(_kintoWallet).balance;

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -344,7 +344,7 @@ contract KintoWalletFactoryTest is SharedSetup {
         assertEq(address(123).balance, 1e18);
     }
 
-    function testSendMoneyToAccount_WhenCallerIsOwnerAndTargetIsKYC() public {
+    function testSendMoneyToAccount_WhenCallerIsOwner_WhenTargetIsKYC() public {
         approveKYC(_kycProvider, _user, _userPk);
         revokeKYC(_kycProvider, _owner, _ownerPk);
         vm.prank(_owner);

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -386,7 +386,7 @@ contract KintoWalletFactoryTest is SharedSetup {
         _walletFactory.sendMoneyToAccount{value: 1e18}(address(123));
     }
 
-    function testSendMoneyToAccount_RevertWhen_CallerKYCButTargetisNot() public {
+    function testSendMoneyToAccount_RevertWhen_CallerIsKYCd_WhenTargetisNotKYCd() public {
         approveKYC(_kycProvider, _user, _userPk);
         vm.deal(_user, 1 ether);
         vm.prank(_user);

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -390,7 +390,7 @@ contract KintoWalletFactoryTest is SharedSetup {
         approveKYC(_kycProvider, _user, _userPk);
         vm.deal(_user, 1 ether);
         vm.prank(_user);
-        vm.expectRevert("Invalid target address");
+        vm.expectRevert("Target is not valid");
         _walletFactory.sendMoneyToAccount{value: 1e18}(address(123));
     }
 

--- a/test/KintoWalletFactory.t.sol
+++ b/test/KintoWalletFactory.t.sol
@@ -374,7 +374,7 @@ contract KintoWalletFactoryTest is SharedSetup {
     function testSendMoneyToAccount_When_CallerKYCAndTargetContract() public {
         vm.deal(_kycProvider, 1 ether);
         vm.prank(_kycProvider);
-        uint beforeBalance = address(_kintoWallet).balance;
+        uint256 beforeBalance = address(_kintoWallet).balance;
         _walletFactory.sendMoneyToAccount{value: 1e18}(address(_kintoWallet));
         assertEq(address(_kintoWallet).balance, beforeBalance + 1e18);
     }


### PR DESCRIPTION
Small PR to prevent users from sending money to any account that is not KYCed