### PR TITLE
add migration to revoke KYC PROVIDER ROLE to previous provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Alternatively, you run `yarn test`
 
 To run tests on a fork from mainnet you can se the env var `FORK=true`
 ```
-FORK=true forge test
+FORK=true FOUNDRY_EVM_VERSION=shanghai forge test -vvvv --match-contract BridgerTest
 ```
 Alternatively, you run `yarn test-mainnet`
 

--- a/script/migrations/34-deploy_wallet_factory_v10.sol
+++ b/script/migrations/34-deploy_wallet_factory_v10.sol
@@ -16,8 +16,7 @@ contract KintoMigration34DeployScript is MigrationHelper {
         );
         _deployImplementationAndUpgrade("KintoWalletFactory", "V10", bytecode);
 
-        bytecode =
-            abi.encodePacked(type(Faucet).creationCode, abi.encode(_getChainDeployment("KintoWalletFactory")));
+        bytecode = abi.encodePacked(type(Faucet).creationCode, abi.encode(_getChainDeployment("KintoWalletFactory")));
         _deployImplementationAndUpgrade("Faucet", "V7", bytecode);
     }
 }

--- a/script/migrations/37-remove-kyc-provider.sol
+++ b/script/migrations/37-remove-kyc-provider.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "../../src/KintoID.sol";
+import "../../src/wallet/KintoWalletFactory.sol";
+import "./utils/MigrationHelper.sol";
+
+contract KintoMigration37DeployScript is MigrationHelper {
+    using ECDSAUpgradeable for bytes32;
+
+    function run() public override {
+        super.run();
+
+        KintoID kintoID = KintoID(_getChainDeployment("KintoID"));
+        KintoWalletFactory walletFactory = KintoWalletFactory(_getChainDeployment("KintoWalletFactory"));
+
+        // providers
+        address DEFENDER_KYC_PROVIDER = 0x6E31039abF8d248aBed57E307C9E1b7530c269E4;
+        uint256 previousProviderPk = vm.envUint("PRIVATE_KEY_KYC_PROVIDER");
+        address previousProvider = vm.addr(previousProviderPk);
+
+        // transfer ETH balance from previousProvider to relayer
+        uint256 balance = previousProvider.balance;
+        uint256 defenderBalance = DEFENDER_KYC_PROVIDER.balance;
+
+        vm.broadcast(previousProviderPk);
+        walletFactory.sendMoneyToAccount{value: balance}(DEFENDER_KYC_PROVIDER);
+
+        assertTrue(previousProvider.balance == 0);
+        assertTrue(DEFENDER_KYC_PROVIDER.balance == defenderBalance + balance);
+
+        // revoke KYC_PROVIDER role from previous provider
+        bytes32 role = kintoID.KYC_PROVIDER_ROLE();
+        assertTrue(kintoID.hasRole(role, previousProvider));
+
+        vm.broadcast();
+        kintoID.revokeRole(role, previousProvider);
+        assertFalse(kintoID.hasRole(role, previousProvider));
+    }
+}


### PR DESCRIPTION
Adds a migration to:
- transfer ETH from previous KYC provider to Defender's KYC Provider relayer
- revokes `KYC_PROVIDER_ROLE` role from previous provider

[ONLY MERGE AFTER E2E TESTS ]