### PR TITLE
chore: prevent invalid origin on token bridges

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -20,3 +20,9 @@ runs:
         restore-keys: |
           forge-${{ github.base_ref }}
           forge-
+
+    - name: Install token-bridge-contracts submodule dependencies
+      shell: bash
+      run: |
+        cd lib/token-bridge-contracts
+        npm install

--- a/.github/workflows/forge-mainnet-test.yml
+++ b/.github/workflows/forge-mainnet-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with: 
           submodules: recursive
-      
+
       - uses: ./.github/actions/install
 
       - name: Build contracts

--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with: 
           submodules: recursive
-      
+
       - uses: ./.github/actions/install
 
       - name: Build contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
+[submodule "lib/token-bridge-contracts"]
+	path = lib/token-bridge-contracts
+	url = https://github.com/OffchainLabs/token-bridge-contracts

--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ This repository contains all the core smart contracts available at Kinto.
 
 ## Requirements
 
-- Install [Foundry](https://book.getfoundry.sh/getting-started/installation)
-- Copy .env.sample to .env and fill the values. After you deploy the proxy make sure to fill its address as well.
+- [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- Yarn or NPM
+
+## Install dependencies
+- Run `yarn install` to install all forge dependencies 
+  - Alternative, you can run `forge install` and then `cd lib/token-bridge-contracts && yarn`
+- Copy `.env.sample` to `.env` and fill the values. After you deploy the proxy make sure to fill its address as well.
 
 ### Enable CREATE2 in a custom chain (only needed in a custom chain)
 
@@ -78,7 +83,7 @@ forge test
 ```
 Alternatively, you run `yarn test`
 
-To run tests on a fork from mainnet you can se the env var `FORK=true`
+To run tests on a fork from mainnet you need to set the env vars `FORK=true` and `FOUNDRY_EVM_VERSION=shanghai`
 ```
 FORK=true FOUNDRY_EVM_VERSION=shanghai forge test -vvvv --match-contract BridgerTest
 ```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   },
   "license": "MIT",
   "scripts": {
+    "install": "forge install && cd lib/token-bridge-contracts && yarn",
     "test": "source .env && FORK=false forge test -vvvv",
-    "test-mainnet": "source .env && FORK=true forge test -vvvv",
+    "test-mainnet": "source .env && FORK=true FOUNDRY_EVM_VERSION=shanghai forge test -vvvv",
+    "coverage": "forge coverage",
     "export-testnet": "source .env && node ./utils/export.js $TEST_NETWORK_ID",
     "export-mainnet": "source .env && node ./utils/export.js $MAINNET_NETWORK_ID",
     "export-eth-mainnet": "source .env && node ./utils/export.js 1"

--- a/remappings.txt
+++ b/remappings.txt
@@ -12,3 +12,5 @@ lib/account-abstraction:@openzeppelin/=lib/openzeppelin-contracts
 @openzeppelin-5.0.1/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable-5.0.1/contracts/
 
 @solady/=lib/solady/src/
+
+@token-bridge-contracts/=lib/token-bridge-contracts/

--- a/script/migrations/41-upgrade_token_bridge_contracts.sol
+++ b/script/migrations/41-upgrade_token_bridge_contracts.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import "../../src/wallet/KintoWalletFactory.sol";
+import "../../src/bridger/token-bridge-contracts//L2CustomGateway.sol";
+import "../../src/bridger/token-bridge-contracts//L2ERC20Gateway.sol";
+import "../../src/bridger/token-bridge-contracts//L2WethGateway.sol";
+
+import "./utils/MigrationHelper.sol";
+
+interface IUpgradeExecutor {
+    function initialize(address admin, address[] memory executors) external;
+    function execute(address upgrade, bytes memory upgradeCallData) external payable;
+    function executeCall(address target, bytes memory targetCallData) external payable;
+}
+
+contract KintoMigration41DeployScript is MigrationHelper {
+    using ECDSAUpgradeable for bytes32;
+
+    function run() public override {
+        super.run();
+
+        console.log("Executing from address", msg.sender);
+
+        TransparentUpgradeableProxy l2CustomGateway =
+            TransparentUpgradeableProxy(payable(0x06FcD8264caF5c28D86eb4630c20004aa1faAaA8));
+        TransparentUpgradeableProxy l2ERC20Gateway =
+            TransparentUpgradeableProxy(payable(0x87799989341A07F495287B1433eea98398FD73aA));
+        TransparentUpgradeableProxy l2WethGateway =
+            TransparentUpgradeableProxy(payable(0xd563ECBDF90EBA783d0a218EFf158C1263ad02BE));
+        ProxyAdmin proxyAdmin = ProxyAdmin(0x9eC0253E4174a14C0536261888416451A407Bf79);
+        IUpgradeExecutor upgradeExecutor = IUpgradeExecutor(0x88e03D41a6EAA9A0B93B0e2d6F1B34619cC4319b);
+
+        // executor
+        address executor = 0x09d34B74cd8B1c4394A3cD9630E1Ba027E6ED4F5; // FIXME: this is Caldera that needs to add as executor
+
+        // L2CustomGateway
+        bytes memory bytecode = abi.encodePacked(type(L2CustomGateway).creationCode);
+        address impl = _deployImplementation("L2CustomGateway", "V2", bytecode);
+        bytes memory upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2CustomGateway, impl);
+
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+
+        // L2ERC20Gateway
+        bytecode = abi.encodePacked(type(L2ERC20Gateway).creationCode);
+        impl = _deployImplementation("L2ERC20Gateway", "V2", bytecode);
+        upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2ERC20Gateway, impl);
+
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+
+        // L2WethGateway
+        bytecode = abi.encodePacked(type(L2WethGateway).creationCode);
+        impl = _deployImplementation("L2WethGateway", "V2", bytecode);
+        upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2WethGateway, impl);
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+    }
+}

--- a/script/migrations/42-upgrade_token_bridge_contracts.sol
+++ b/script/migrations/42-upgrade_token_bridge_contracts.sol
@@ -33,7 +33,7 @@ contract KintoMigration41DeployScript is MigrationHelper {
         ProxyAdmin proxyAdmin = ProxyAdmin(0x9eC0253E4174a14C0536261888416451A407Bf79);
         IUpgradeExecutor upgradeExecutor = IUpgradeExecutor(0x88e03D41a6EAA9A0B93B0e2d6F1B34619cC4319b);
 
-        if (!upgradeExecutor.hasRole(keccak256("EXECUTOR_ROLE"), vm.addr(deployerPrivateKey))) {
+        if (!upgradeExecutor.hasRole(keccak256("EXECUTOR_ROLE"), msg.sender)) {
             revert("Sender does not have EXECUTOR_ROLE");
         }
 

--- a/script/migrations/42-upgrade_token_bridge_contracts.sol
+++ b/script/migrations/42-upgrade_token_bridge_contracts.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import "../../src/wallet/KintoWalletFactory.sol";
+import "../../src/bridger/token-bridge-contracts//L2CustomGateway.sol";
+import "../../src/bridger/token-bridge-contracts//L2ERC20Gateway.sol";
+import "../../src/bridger/token-bridge-contracts//L2WethGateway.sol";
+
+import "./utils/MigrationHelper.sol";
+
+interface IUpgradeExecutor {
+    function initialize(address admin, address[] memory executors) external;
+    function execute(address upgrade, bytes memory upgradeCallData) external payable;
+    function executeCall(address target, bytes memory targetCallData) external payable;
+    function hasRole(bytes32 role, address account) external view returns (bool);
+}
+
+contract KintoMigration41DeployScript is MigrationHelper {
+    using ECDSAUpgradeable for bytes32;
+
+    function run() public override {
+        super.run();
+
+        TransparentUpgradeableProxy l2CustomGateway =
+            TransparentUpgradeableProxy(payable(0x06FcD8264caF5c28D86eb4630c20004aa1faAaA8));
+        TransparentUpgradeableProxy l2ERC20Gateway =
+            TransparentUpgradeableProxy(payable(0x87799989341A07F495287B1433eea98398FD73aA));
+        TransparentUpgradeableProxy l2WethGateway =
+            TransparentUpgradeableProxy(payable(0xd563ECBDF90EBA783d0a218EFf158C1263ad02BE));
+        ProxyAdmin proxyAdmin = ProxyAdmin(0x9eC0253E4174a14C0536261888416451A407Bf79);
+        IUpgradeExecutor upgradeExecutor = IUpgradeExecutor(0x88e03D41a6EAA9A0B93B0e2d6F1B34619cC4319b);
+
+        if (!upgradeExecutor.hasRole(keccak256("EXECUTOR_ROLE"), vm.addr(deployerPrivateKey))) {
+            revert("Sender does not have EXECUTOR_ROLE");
+        }
+
+        // L2CustomGateway
+        bytes memory bytecode = abi.encodePacked(type(L2CustomGateway).creationCode);
+        address impl = _deployImplementation("L2CustomGateway", "V2", bytecode);
+        bytes memory upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2CustomGateway, impl);
+
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+
+        // L2ERC20Gateway
+        bytecode = abi.encodePacked(type(L2ERC20Gateway).creationCode);
+        impl = _deployImplementation("L2ERC20Gateway", "V2", bytecode);
+        upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2ERC20Gateway, impl);
+
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+
+        // L2WethGateway
+        bytecode = abi.encodePacked(type(L2WethGateway).creationCode);
+        impl = _deployImplementation("L2WethGateway", "V2", bytecode);
+        upgradeCallData = abi.encodeWithSelector(ProxyAdmin.upgrade.selector, l2WethGateway, impl);
+        vm.broadcast();
+        upgradeExecutor.executeCall(address(proxyAdmin), upgradeCallData);
+    }
+}

--- a/src/bridger/token-bridge-contracts/L2ArbitrumGateway.sol
+++ b/src/bridger/token-bridge-contracts/L2ArbitrumGateway.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/Address.sol";
+import "../../libraries/AddressAliasHelper.sol";
+import "../../libraries/BytesLib.sol";
+import "../../libraries/ProxyUtil.sol";
+
+import "../IArbToken.sol";
+
+import "../L2ArbitrumMessenger.sol";
+import "../../libraries/gateway/GatewayMessageHandler.sol";
+import "../../libraries/gateway/TokenGateway.sol";
+
+/**
+ * @title Common interface for gatways on Arbitrum messaging to L1.
+ */
+abstract contract L2ArbitrumGateway is L2ArbitrumMessenger, TokenGateway {
+    using Address for address;
+
+    uint256 public exitNum;
+
+    event DepositFinalized(address indexed l1Token, address indexed _from, address indexed _to, uint256 _amount);
+
+    event WithdrawalInitiated(
+        address l1Token,
+        address indexed _from,
+        address indexed _to,
+        uint256 indexed _l2ToL1Id,
+        uint256 _exitNum,
+        uint256 _amount
+    );
+
+    modifier onlyCounterpartGateway() override {
+        require(msg.sender == AddressAliasHelper.applyL1ToL2Alias(counterpartGateway), "ONLY_COUNTERPART_GATEWAY");
+        _;
+    }
+
+    function postUpgradeInit() external {
+        // it is assumed the L2 Arbitrum Gateway contract is behind a Proxy controlled by a proxy admin
+        // this function can only be called by the proxy admin contract
+        address proxyAdmin = ProxyUtil.getProxyAdmin();
+        require(msg.sender == proxyAdmin, "NOT_FROM_ADMIN");
+        // this has no other logic since the current upgrade doesn't require this logic
+    }
+
+    function _initialize(address _l1Counterpart, address _router) internal override {
+        TokenGateway._initialize(_l1Counterpart, _router);
+        // L1 gateway must have a router
+        require(_router != address(0), "BAD_ROUTER");
+    }
+
+    function createOutboundTx(address _from, uint256, /* _tokenAmount */ bytes memory _outboundCalldata)
+        internal
+        virtual
+        returns (uint256)
+    {
+        // We make this function virtual since outboundTransfer logic is the same for many gateways
+        // but sometimes (ie weth) you construct the outgoing message differently.
+
+        // exitNum incremented after being included in _outboundCalldata
+        exitNum++;
+        return sendTxToL1(
+            // default to sending no callvalue to the L1
+            0,
+            _from,
+            counterpartGateway,
+            _outboundCalldata
+        );
+    }
+
+    function getOutboundCalldata(address _token, address _from, address _to, uint256 _amount, bytes memory _data)
+        public
+        view
+        override
+        returns (bytes memory outboundCalldata)
+    {
+        outboundCalldata = abi.encodeWithSelector(
+            ITokenGateway.finalizeInboundTransfer.selector,
+            _token,
+            _from,
+            _to,
+            _amount,
+            GatewayMessageHandler.encodeFromL2GatewayMsg(exitNum, _data)
+        );
+
+        return outboundCalldata;
+    }
+
+    function outboundTransfer(address _l1Token, address _to, uint256 _amount, bytes calldata _data)
+        public
+        payable
+        returns (bytes memory)
+    {
+        return outboundTransfer(_l1Token, _to, _amount, 0, 0, _data);
+    }
+
+    /**
+     * @notice Initiates a token withdrawal from Arbitrum to Ethereum
+     * @param _l1Token l1 address of token
+     * @param _to destination address
+     * @param _amount amount of tokens withdrawn
+     * @return res encoded unique identifier for withdrawal
+     */
+    function outboundTransfer(
+        address _l1Token,
+        address _to,
+        uint256 _amount,
+        uint256, /* _maxGas */
+        uint256, /* _gasPriceBid */
+        bytes calldata _data
+    ) public payable override returns (bytes memory res) {
+        // This function is set as public and virtual so that subclasses can override
+        // it and add custom validation for callers (ie only whitelisted users)
+
+        // the function is marked as payable to conform to the inheritance setup
+        // this particular code path shouldn't have a msg.value > 0
+        // TODO: remove this invariant for execution markets
+        require(msg.value == 0, "NO_VALUE");
+
+        address _from;
+        bytes memory _extraData;
+        {
+            if (isRouter(msg.sender)) {
+                (_from, _extraData) = GatewayMessageHandler.parseFromRouterToGateway(_data);
+            } else {
+                _from = msg.sender;
+                _extraData = _data;
+            }
+        }
+        // the inboundEscrowAndCall functionality has been disabled, so no data is allowed
+        require(_extraData.length == 0, "EXTRA_DATA_DISABLED");
+
+        uint256 id;
+        {
+            address l2Token = calculateL2TokenAddress(_l1Token);
+            require(l2Token.isContract(), "TOKEN_NOT_DEPLOYED");
+            require(IArbToken(l2Token).l1Address() == _l1Token, "NOT_EXPECTED_L1_TOKEN");
+
+            _amount = outboundEscrowTransfer(l2Token, _from, _amount);
+            id = triggerWithdrawal(_l1Token, _from, _to, _amount, _extraData);
+        }
+        return abi.encode(id);
+    }
+
+    function triggerWithdrawal(address _l1Token, address _from, address _to, uint256 _amount, bytes memory _data)
+        internal
+        returns (uint256)
+    {
+        // exit number used for tradeable exits
+        uint256 currExitNum = exitNum;
+        // unique id used to identify the L2 to L1 tx
+        uint256 id = createOutboundTx(_from, _amount, getOutboundCalldata(_l1Token, _from, _to, _amount, _data));
+        emit WithdrawalInitiated(_l1Token, _from, _to, id, currExitNum, _amount);
+        return id;
+    }
+
+    function outboundEscrowTransfer(address _l2Token, address _from, uint256 _amount)
+        internal
+        virtual
+        returns (uint256 amountBurnt)
+    {
+        // this method is virtual since different subclasses can handle escrow differently
+        // user funds are escrowed on the gateway using this function
+        // burns L2 tokens in order to release escrowed L1 tokens
+        IArbToken(_l2Token).bridgeBurn(_from, _amount);
+        // by default we assume that the amount we send to bridgeBurn is the amount burnt
+        // this might not be the case for every token
+        return _amount;
+    }
+
+    function inboundEscrowTransfer(address _l2Address, address _dest, uint256 _amount) internal virtual {
+        // this method is virtual since different subclasses can handle escrow differently
+        IArbToken(_l2Address).bridgeMint(_dest, _amount);
+    }
+
+    /**
+     * @notice Mint on L2 upon L1 deposit.
+     * If token not yet deployed and symbol/name/decimal data is included, deploys StandardArbERC20
+     * @dev Callable only by the L1ERC20Gateway.outboundTransfer method. For initial deployments of a token the L1 L1ERC20Gateway
+     * is expected to include the deployData. If not a L1 withdrawal is automatically triggered for the user
+     * @param _token L1 address of ERC20
+     * @param _from account that initiated the deposit in the L1
+     * @param _to account to be credited with the tokens in the L2 (can be the user's L2 account or a contract)
+     * @param _amount token amount to be minted to the user
+     * @param _data encoded symbol/name/decimal data for deploy, in addition to any additional callhook data
+     */
+    function finalizeInboundTransfer(address _token, address _from, address _to, uint256 _amount, bytes calldata _data)
+        external
+        payable
+        override
+        onlyCounterpartGateway
+    {
+        (bytes memory gatewayData, bytes memory callHookData) = GatewayMessageHandler.parseFromL1GatewayMsg(_data);
+
+        if (callHookData.length != 0) {
+            // callHookData should always be 0 since inboundEscrowAndCall is disabled
+            callHookData = bytes("");
+        }
+
+        address expectedAddress = calculateL2TokenAddress(_token);
+
+        if (!expectedAddress.isContract()) {
+            bool shouldHalt = handleNoContract(_token, expectedAddress, _from, _to, _amount, gatewayData);
+            if (shouldHalt) return;
+        }
+        // ignores gatewayData if token already deployed
+
+        {
+            // validate if L1 address supplied matches that of the expected L2 address
+            (bool success, bytes memory _l1AddressData) =
+                expectedAddress.staticcall(abi.encodeWithSelector(IArbToken.l1Address.selector));
+
+            bool shouldWithdraw;
+            if (!success || _l1AddressData.length < 32) {
+                shouldWithdraw = true;
+            } else {
+                // we do this in the else branch since we want to avoid reverts
+                // and `toAddress` reverts if _l1AddressData has a short length
+                // `_l1AddressData` should be 12 bytes of padding then 20 bytes for the address
+                address expectedL1Address = BytesLib.toAddress(_l1AddressData, 12);
+                if (expectedL1Address != _token) {
+                    shouldWithdraw = true;
+                }
+            }
+
+            if (shouldWithdraw) {
+                // we don't need the return value from triggerWithdrawal since this is forcing
+                // a withdrawal back to the L1 instead of composing with a L2 dapp
+                triggerWithdrawal(_token, address(this), _from, _amount, "");
+                return;
+            }
+        }
+
+        inboundEscrowTransfer(expectedAddress, _to, _amount);
+        emit DepositFinalized(_token, _from, _to, _amount);
+
+        return;
+    }
+
+    // returns if function should halt after
+    function handleNoContract(
+        address _l1Token,
+        address expectedL2Address,
+        address _from,
+        address _to,
+        uint256 _amount,
+        bytes memory gatewayData
+    ) internal virtual returns (bool shouldHalt);
+}

--- a/src/bridger/token-bridge-contracts/L2CustomGateway.sol
+++ b/src/bridger/token-bridge-contracts/L2CustomGateway.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.8.0;
+
+import "./L2ArbitrumGateway.sol";
+import "../../libraries/gateway/ICustomGateway.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract L2CustomGateway is L2ArbitrumGateway, ICustomGateway {
+    // stores addresses of L2 tokens to be used
+    mapping(address => address) public override l1ToL2Token;
+
+    function initialize(address _l1Counterpart, address _router) public {
+        L2ArbitrumGateway._initialize(_l1Counterpart, _router);
+    }
+
+    /**
+     * @notice internal utility function used to handle when no contract is deployed at expected address
+     */
+    function handleNoContract(
+        address _l1Token,
+        address, /* expectedL2Address */
+        address _from,
+        address, /* _to */
+        uint256 _amount,
+        bytes memory /* gatewayData */
+    ) internal override returns (bool shouldHalt) {
+        // it is assumed that the custom token is deployed in the L2 before deposits are made
+        // trigger withdrawal
+        // we don't need the return value from triggerWithdrawal since this is forcing a withdrawal back to the L1
+        // instead of composing with a L2 dapp
+        triggerWithdrawal(_l1Token, address(this), _from, _amount, "");
+        return true;
+    }
+
+    /**
+     * @notice Calculate the address used when bridging an ERC20 token
+     * @dev the L1 and L2 address oracles may not always be in sync.
+     * For example, a custom token may have been registered but not deploy or the contract self destructed.
+     * @param l1ERC20 address of L1 token
+     * @return L2 address of a bridged ERC20 token
+     */
+    function calculateL2TokenAddress(address l1ERC20) public view override returns (address) {
+        return l1ToL2Token[l1ERC20];
+    }
+
+    function registerTokenFromL1(address[] calldata l1Address, address[] calldata l2Address)
+        external
+        onlyCounterpartGateway
+    {
+        // we assume both arrays are the same length, safe since its encoded by the L1
+        for (uint256 i = 0; i < l1Address.length; i++) {
+            // here we don't check if l2Address is a contract and instead deal with that behaviour
+            // in `handleNoContract` this way we keep the l1 and l2 address oracles in sync
+            l1ToL2Token[l1Address[i]] = l2Address[i];
+            emit TokenSet(l1Address[i], l2Address[i]);
+        }
+    }
+}

--- a/src/bridger/token-bridge-contracts/L2CustomGateway.sol
+++ b/src/bridger/token-bridge-contracts/L2CustomGateway.sol
@@ -19,7 +19,7 @@
 pragma solidity ^0.8.0;
 
 import "./L2ArbitrumGateway.sol";
-import "../../libraries/gateway/ICustomGateway.sol";
+import "@token-bridge-contracts/contracts/tokenbridge/libraries/gateway/ICustomGateway.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract L2CustomGateway is L2ArbitrumGateway, ICustomGateway {

--- a/src/bridger/token-bridge-contracts/L2ERC20Gateway.sol
+++ b/src/bridger/token-bridge-contracts/L2ERC20Gateway.sol
@@ -21,8 +21,8 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "./L2ArbitrumGateway.sol";
-import "../StandardArbERC20.sol";
-import "../../libraries/ClonableBeaconProxy.sol";
+import "@token-bridge-contracts/contracts/tokenbridge/arbitrum/StandardArbERC20.sol";
+import "@token-bridge-contracts/contracts/tokenbridge/libraries/ClonableBeaconProxy.sol";
 
 contract L2ERC20Gateway is L2ArbitrumGateway {
     address public beaconProxyFactory;

--- a/src/bridger/token-bridge-contracts/L2ERC20Gateway.sol
+++ b/src/bridger/token-bridge-contracts/L2ERC20Gateway.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
+import "./L2ArbitrumGateway.sol";
+import "../StandardArbERC20.sol";
+import "../../libraries/ClonableBeaconProxy.sol";
+
+contract L2ERC20Gateway is L2ArbitrumGateway {
+    address public beaconProxyFactory;
+
+    function initialize(address _l1Counterpart, address _router, address _beaconProxyFactory) public {
+        L2ArbitrumGateway._initialize(_l1Counterpart, _router);
+        require(_beaconProxyFactory != address(0), "INVALID_BEACON");
+        beaconProxyFactory = _beaconProxyFactory;
+    }
+
+    /**
+     * @notice Calculate the address used when bridging an ERC20 token
+     * @dev the L1 and L2 address oracles may not always be in sync.
+     * For example, a custom token may have been registered but not deploy or the contract self destructed.
+     * @param l1ERC20 address of L1 token
+     * @return L2 address of a bridged ERC20 token
+     */
+    function calculateL2TokenAddress(address l1ERC20) public view virtual override returns (address) {
+        // this method is marked virtual to be overriden in subclasses used in testing
+        return BeaconProxyFactory(beaconProxyFactory).calculateExpectedAddress(address(this), getUserSalt(l1ERC20));
+    }
+
+    function cloneableProxyHash() public view returns (bytes32) {
+        return BeaconProxyFactory(beaconProxyFactory).cloneableProxyHash();
+    }
+
+    function getUserSalt(address l1ERC20) public pure returns (bytes32) {
+        return keccak256(abi.encode(l1ERC20));
+    }
+
+    /**
+     * @notice internal utility function used to deploy ERC20 tokens with the beacon proxy pattern.
+     * @dev the transparent proxy implementation by OpenZeppelin can't be used if we want to be able to
+     * upgrade the token logic.
+     * @param l1ERC20 L1 address of ERC20
+     * @param expectedL2Address L2 address of ERC20
+     * @param deployData encoded symbol/name/decimal data for initial deploy
+     */
+    function handleNoContract(
+        address l1ERC20,
+        address expectedL2Address,
+        address _from,
+        address, /* _to */
+        uint256 _amount,
+        bytes memory deployData
+    ) internal override returns (bool shouldHalt) {
+        bytes32 userSalt = getUserSalt(l1ERC20);
+        address createdContract = BeaconProxyFactory(beaconProxyFactory).createProxy(userSalt);
+
+        StandardArbERC20(createdContract).bridgeInit(l1ERC20, deployData);
+
+        if (createdContract == expectedL2Address) {
+            return false;
+        } else {
+            // trigger withdrawal then halt
+            // this codepath should only be hit if the system is setup incorrectly
+            // this withdrawal is for error recovery, not composing with L2 dapps, so we ignore the return value
+            triggerWithdrawal(l1ERC20, address(this), _from, _amount, "");
+            return true;
+        }
+    }
+}

--- a/src/bridger/token-bridge-contracts/L2WethGateway.sol
+++ b/src/bridger/token-bridge-contracts/L2WethGateway.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2020, Offchain Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pragma solidity ^0.8.0;
+
+import "./L2ArbitrumGateway.sol";
+import "../../libraries/IWETH9.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract L2WethGateway is L2ArbitrumGateway {
+    using SafeERC20 for IERC20;
+
+    address public l1Weth;
+    address public l2Weth;
+
+    function initialize(address _l1Counterpart, address _router, address _l1Weth, address _l2Weth) public {
+        L2ArbitrumGateway._initialize(_l1Counterpart, _router);
+        require(_l1Weth != address(0), "INVALID_L1WETH");
+        require(_l2Weth != address(0), "INVALID_L2WETH");
+        l1Weth = _l1Weth;
+        l2Weth = _l2Weth;
+    }
+
+    /**
+     * @notice internal utility function used to handle when no contract is deployed at expected address
+     * @param l1ERC20 L1 address of ERC20
+     */
+    function handleNoContract(
+        address l1ERC20,
+        address, /* expectedL2Address */
+        address _from,
+        address, /* _to */
+        uint256 _amount,
+        bytes memory /* deployData */
+    ) internal override returns (bool shouldHalt) {
+        // it is assumed that the custom token is deployed in the L2 before deposits are made
+        // trigger withdrawal
+        // this codepath should only be hit if the system is setup incorrectly
+        // this withdrawal is for error recovery, not composing with L2 dapps, so we ignore the return value
+        triggerWithdrawal(l1ERC20, address(this), _from, _amount, "");
+        return true;
+    }
+
+    /**
+     * @notice Calculate the address used when bridging an ERC20 token
+     * @dev the L1 and L2 address oracles may not always be in sync.
+     * For example, a custom token may have been registered but not deploy or the contract self destructed.
+     * @param l1ERC20 address of L1 token
+     * @return L2 address of a bridged ERC20 token
+     */
+    function calculateL2TokenAddress(address l1ERC20) public view override returns (address) {
+        if (l1ERC20 != l1Weth) {
+            // invalid L1 weth address
+            return address(0);
+        }
+        return l2Weth;
+    }
+
+    function inboundEscrowTransfer(address _l2TokenAddress, address _dest, uint256 _amount) internal override {
+        IWETH9(_l2TokenAddress).deposit{value: _amount}();
+        IERC20(_l2TokenAddress).safeTransfer(_dest, _amount);
+    }
+
+    function createOutboundTx(address _from, uint256 _tokenAmount, bytes memory _outboundCalldata)
+        internal
+        override
+        returns (uint256)
+    {
+        // exitNum incremented after being included in _outboundCalldata
+        exitNum++;
+        return sendTxToL1(
+            // we send the amount of weth withdrawn as callvalue to the L1 gateway
+            _tokenAmount,
+            _from,
+            counterpartGateway,
+            _outboundCalldata
+        );
+    }
+
+    receive() external payable {}
+}

--- a/src/bridger/token-bridge-contracts/L2WethGateway.sol
+++ b/src/bridger/token-bridge-contracts/L2WethGateway.sol
@@ -19,7 +19,7 @@
 pragma solidity ^0.8.0;
 
 import "./L2ArbitrumGateway.sol";
-import "../../libraries/IWETH9.sol";
+import "@token-bridge-contracts/contracts/tokenbridge/libraries/IWETH9.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/test/bridger/ArbitrumBridger.t.sol
+++ b/test/bridger/ArbitrumBridger.t.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+
+import "../../src/bridger/token-bridge-contracts/L2ArbitrumGateway.sol";
+import "../../src/bridger/token-bridge-contracts/L2CustomGateway.sol";
+import "../../src/bridger/token-bridge-contracts/L2ERC20Gateway.sol";
+import "../../src/bridger/token-bridge-contracts/L2WethGateway.sol";
+
+import {L2ArbitrumGatewayTest} from "@token-bridge-contracts/test-foundry/L2ArbitrumGateway.t.sol";
+import {L2CustomToken} from "@token-bridge-contracts/test-foundry/L2CustomGateway.t.sol";
+import {StandardArbERC20} from "@token-bridge-contracts/contracts/tokenbridge/arbitrum/StandardArbERC20.sol";
+import {
+    BeaconProxyFactory,
+    ClonableBeaconProxy
+} from "@token-bridge-contracts/contracts/tokenbridge/libraries/ClonableBeaconProxy.sol";
+import {aeWETH} from "@token-bridge-contracts/contracts/tokenbridge/libraries/aeWETH.sol";
+
+import {UpgradeableBeacon} from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import "../../src/interfaces/IKintoWallet.sol";
+
+import {SharedSetup, UserOperation} from "../SharedSetup.t.sol";
+
+contract ArbitrumBridgerTest is SharedSetup, L2ArbitrumGatewayTest {
+    L2CustomGateway l2CustomGateway;
+    L2ERC20Gateway l2ERC20Gateway;
+    L2WethGateway l2WethGateway;
+    address public l2BeaconProxyFactory;
+    address public l1Token = makeAddr("l1Token");
+    address public l1Weth = makeAddr("l1Weth");
+    address public l2Weth;
+
+    event InvalidDepositOrigin(address indexed _from, address indexed _to);
+
+    function setUp() public override {
+        super.setUp();
+
+        // deploy contracts
+        l2CustomGateway = new L2CustomGateway();
+        l2ERC20Gateway = new L2ERC20Gateway();
+        l2WethGateway = new L2WethGateway();
+
+        // create beacon
+        StandardArbERC20 standardArbERC20 = new StandardArbERC20();
+        UpgradeableBeacon beacon = new UpgradeableBeacon(address(standardArbERC20));
+        l2BeaconProxyFactory = address(new BeaconProxyFactory());
+        BeaconProxyFactory(l2BeaconProxyFactory).initialize(address(beacon));
+
+        ProxyAdmin pa = new ProxyAdmin();
+        l2Weth = address(new TransparentUpgradeableProxy(address(new aeWETH()), address(pa), ""));
+        aeWETH(payable(l2Weth)).initialize("WETH", "WETH", 18, address(l2WethGateway), l1Weth);
+
+        // initialize
+        l2CustomGateway.initialize(l1Counterpart, router);
+        l2ERC20Gateway.initialize(l1Counterpart, router, l2BeaconProxyFactory);
+        l2WethGateway.initialize(l1Counterpart, router, l1Weth, l2Weth);
+
+        // not used here but needed for L2ArbitrumGatewayTest compliance
+        address gateway = address(l2CustomGateway);
+        assembly {
+            sstore(l2Gateway.slot, gateway)
+        }
+    }
+
+    function testFinalizeInboundTransfer_WhenL2CustomGateway() public {
+        address l2Token = l2CustomGateway.calculateL2TokenAddress(l1Token);
+
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData = new bytes(0);
+        bytes memory callHookData = new bytes(0);
+
+        // register custom token
+        address l2CustomToken = registerToken();
+
+        // make sure `sender` is not whitelisted
+        assertFalse(IKintoWallet(receiver).isFunderWhitelisted(sender));
+
+        // whitelist `sender` and try again
+        whitelistFunder(sender);
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2CustomGateway.finalizeInboundTransfer(
+            l1Token, sender, receiver, amount, abi.encode(gatewayData, callHookData)
+        );
+
+        // check L2 token has been created
+        assertTrue(l2CustomToken.code.length > 0, "L2 token is supposed to be created");
+
+        // check tokens have been minted to receiver;
+        assertEq(ERC20(l2CustomToken).balanceOf(receiver), amount, "Invalid receiver balance");
+    }
+
+    function testFinalizeInboundTransfer_WhenL2CustomGateway_WhenInvalidOrigin() public {
+        address l2Token = l2CustomGateway.calculateL2TokenAddress(l1Token);
+
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData = new bytes(0);
+        bytes memory callHookData = new bytes(0);
+
+        // register custom token
+        address l2CustomToken = registerToken();
+
+        // make sure `sender` is not whitelisted
+        assertFalse(IKintoWallet(receiver).isFunderWhitelisted(sender));
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalInitiated(l1Token, address(l2CustomGateway), sender, 0, 0, amount);
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit InvalidDepositOrigin(sender, receiver);
+
+        // finalize deposit
+        vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2CustomGateway.finalizeInboundTransfer(
+            l1Token, sender, receiver, amount, abi.encode(gatewayData, callHookData)
+        );
+    }
+
+    function testFinalizeInboundTransfer_WhenL2ERC20Gateway() public {
+        address l2Token = l2ERC20Gateway.calculateL2TokenAddress(l1Token);
+
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData =
+            abi.encode(abi.encode(bytes("Name")), abi.encode(bytes("Symbol")), abi.encode(uint256(18)));
+        bytes memory callHookData = new bytes(0);
+
+        // whitelist `sender` and try again
+        whitelistFunder(sender);
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2ERC20Gateway.finalizeInboundTransfer(l1Token, sender, receiver, amount, abi.encode(gatewayData, callHookData));
+
+        // check L2 token has been created
+        assertTrue(l2Token.code.length > 0, "L2 token is supposed to be created");
+
+        // check tokens have been minted to receiver;
+        assertEq(ERC20(l2Token).balanceOf(receiver), amount, "Invalid receiver balance");
+    }
+
+    function testFinalizeInboundTransfer_WhenL2ERC20Gateway_WhenInvalidOrigin() public {
+        address l2Token = l2ERC20Gateway.calculateL2TokenAddress(l1Token);
+
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData =
+            abi.encode(abi.encode(bytes("Name")), abi.encode(bytes("Symbol")), abi.encode(uint256(18)));
+        bytes memory callHookData = new bytes(0);
+
+        // make sure `sender` is not whitelisted
+        assertFalse(IKintoWallet(receiver).isFunderWhitelisted(sender));
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalInitiated(l1Token, address(l2ERC20Gateway), sender, 0, 0, amount);
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit InvalidDepositOrigin(sender, receiver);
+
+        // finalize deposit
+        vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2ERC20Gateway.finalizeInboundTransfer(l1Token, sender, receiver, amount, abi.encode(gatewayData, callHookData));
+
+        // check L2 token hasn't been created
+        assertEq(l2Token.code.length, 0, "L2 token isn't supposed to be created");
+    }
+
+    function testFinalizeInboundTransfer_WhenL2WethGateway() public {
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData = new bytes(0);
+        bytes memory callHookData = new bytes(0);
+
+        // fund gateway
+        vm.deal(address(l2WethGateway), 100 ether);
+
+        // whitelist `sender` and try again
+        whitelistFunder(sender);
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2WethGateway.finalizeInboundTransfer(l1Weth, sender, receiver, amount, abi.encode(gatewayData, callHookData));
+
+        // check tokens have been minted to receiver;
+        assertEq(aeWETH(payable(l2Weth)).balanceOf(receiver), amount, "Invalid receiver balance");
+    }
+
+    function testFinalizeInboundTransfer_WhenL2WethGateway_WhenInvalidOrigin() public {
+        sender = address(_kintoWallet);
+        receiver = address(_kintoWallet);
+
+        // deposit params
+        bytes memory gatewayData = new bytes(0);
+        bytes memory callHookData = new bytes(0);
+
+        // fund gateway
+        vm.deal(address(l2WethGateway), 100 ether);
+
+        // make sure `sender` is not whitelisted
+        assertFalse(IKintoWallet(receiver).isFunderWhitelisted(sender));
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit WithdrawalInitiated(l1Weth, address(l2WethGateway), sender, 0, 0, amount);
+
+        // check that withdrawal is triggered occurs when deposit is halted
+        vm.expectEmit(true, true, true, true);
+        emit InvalidDepositOrigin(sender, receiver);
+
+        // finalize deposit
+        vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2WethGateway.finalizeInboundTransfer(l1Weth, sender, receiver, amount, abi.encode(gatewayData, callHookData));
+    }
+
+    // bridger L2 tests
+
+    function testFinalizeInboundTransfer_WhenL2ERC20Gateway_WhenDestinationIsBridgerL2() public {
+        address l2Token = l2ERC20Gateway.calculateL2TokenAddress(l1Token);
+
+        sender = address(_kintoWallet);
+        receiver = l2ERC20Gateway.BRIDGER_L2();
+
+        // deposit params
+        bytes memory gatewayData =
+            abi.encode(abi.encode(bytes("Name")), abi.encode(bytes("Symbol")), abi.encode(uint256(18)));
+        bytes memory callHookData = new bytes(0);
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2ERC20Gateway.finalizeInboundTransfer(l1Token, sender, receiver, amount, abi.encode(gatewayData, callHookData));
+
+        // check L2 token has been created
+        assertTrue(l2Token.code.length > 0, "L2 token is supposed to be created");
+
+        // check tokens have been minted to receiver;
+        assertEq(ERC20(l2Token).balanceOf(receiver), amount, "Invalid receiver balance");
+    }
+
+    // note: overriding below tests to comply with L2ArbitrumGatewayTest which is inherited here
+
+    function test_finalizeInboundTransfer() public override {
+        console.log("test_finalizeInboundTransfer");
+    }
+
+    function test_finalizeInboundTransfer_WithCallHook() public override {
+        console.log("test_finalizeInboundTransfer_WithCallHook");
+    }
+
+    function test_outboundTransfer() public override {
+        console.log("test_outboundTransfer");
+    }
+
+    function test_outboundTransfer_4Args() public override {
+        console.log("test_outboundTransfer_4Args");
+    }
+
+    function test_outboundTransfer_revert_NotExpectedL1Token() public override {
+        console.log("test_outboundTransfer_revert_NotExpectedL1Token");
+    }
+
+    // utils
+
+    function whitelistFunder(address _funder) public {
+        address[] memory funders = new address[](1);
+        funders[0] = address(_funder);
+
+        bool[] memory flags = new bool[](1);
+        flags[0] = true;
+
+        vm.prank(address(_kintoWallet));
+        _kintoWallet.setFunderWhitelist(funders, flags);
+
+        assertTrue(IKintoWallet(address(_kintoWallet)).isFunderWhitelisted(address(_funder)));
+    }
+
+    function registerToken() internal virtual returns (address) {
+        address[] memory l1Tokens = new address[](1);
+        l1Tokens[0] = l1Token;
+
+        address[] memory l2Tokens = new address[](1);
+        l2Tokens[0] = address(new L2CustomToken(address(l2CustomGateway), address(l1Token)));
+
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
+        l2CustomGateway.registerTokenFromL1(l1Tokens, l2Tokens);
+
+        return l2Tokens[0];
+    }
+}

--- a/test/bridger/ArbitrumBridger.t.sol
+++ b/test/bridger/ArbitrumBridger.t.sol
@@ -128,7 +128,16 @@ contract ArbitrumBridgerTest is SharedSetup, L2ArbitrumGatewayTest {
         emit DepositSenderNotWhitelisted(sender, receiver);
 
         // finalize deposit
-        vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        if (fork) {
+            vm.mockCall(
+                address(0x0000000000000000000000000000000000000064),
+                abi.encodeWithSelector(ArbSys.sendTxToL1.selector),
+                abi.encode(0)
+            );
+        } else {
+            vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        }
+
         vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
         l2CustomGateway.finalizeInboundTransfer(
             l1Token, sender, receiver, amount, abi.encode(new bytes(0), new bytes(0))
@@ -157,7 +166,16 @@ contract ArbitrumBridgerTest is SharedSetup, L2ArbitrumGatewayTest {
         emit DepositSenderNotWhitelisted(sender, receiver);
 
         // finalize deposit
-        vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        if (fork) {
+            vm.mockCall(
+                address(0x0000000000000000000000000000000000000064),
+                abi.encodeWithSelector(ArbSys.sendTxToL1.selector),
+                abi.encode(0)
+            );
+        } else {
+            vm.etch(0x0000000000000000000000000000000000000064, address(arbSysMock).code);
+        }
+
         vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1Counterpart));
         l2CustomGateway.finalizeInboundTransfer(
             l1Token, sender, receiver, amount, abi.encode(new bytes(0), new bytes(0))
@@ -196,23 +214,23 @@ contract ArbitrumBridgerTest is SharedSetup, L2ArbitrumGatewayTest {
 
     // note: overriding below tests to comply with L2ArbitrumGatewayTest which is inherited here
 
-    function test_finalizeInboundTransfer() public override {
+    function test_finalizeInboundTransfer() public view override {
         console.log("test_finalizeInboundTransfer");
     }
 
-    function test_finalizeInboundTransfer_WithCallHook() public override {
+    function test_finalizeInboundTransfer_WithCallHook() public view override {
         console.log("test_finalizeInboundTransfer_WithCallHook");
     }
 
-    function test_outboundTransfer() public override {
+    function test_outboundTransfer() public view override {
         console.log("test_outboundTransfer");
     }
 
-    function test_outboundTransfer_4Args() public override {
+    function test_outboundTransfer_4Args() public view override {
         console.log("test_outboundTransfer_4Args");
     }
 
-    function test_outboundTransfer_revert_NotExpectedL1Token() public override {
+    function test_outboundTransfer_revert_NotExpectedL1Token() public view override {
         console.log("test_outboundTransfer_revert_NotExpectedL1Token");
     }
 


### PR DESCRIPTION
This PR simply brings Arbitrum's token bridge contracts from their repo and modifies the `L2ArbitrumGateway.finalizeInboundTransfer` which is inherited by `L2CustomGateway`, `L2ERC20Gateway` and `L2WethGateway`.

The modification is simple, it basically initiates a withdrawal back to the L1 if the sender is not whitelisted by the Kinto wallet (via `kintoWallet.setFunderWhitelist`) or if the receiver is not the Bridger L2 contract:
```
if (_to != BRIDGER_L2 && !IKintoWallet(_to).isFunderWhitelisted(_from)) {
  // forcing withdrawal back to the L1
  triggerWithdrawal(_token, address(this), _from, _amount, "");
  emit InvalidDepositOrigin(_from, _to);
  return;
}
```

To run the migration (for testing purposes):
```
forge script ./script/migrations/42-upgrade_token_bridge_contracts.sol --fork-url https://kinto-mainnet.calderachain.xyz/http -vvvv --unlocked --sender 0x09d34B74cd8B1c4394A3cD9630E1Ba027E6ED4F5
```

Diff between original contracts and ours: https://github.com/KintoXYZ/kinto-core/compare/373da6e90acab20c47bce6567cabbc2bfe97fac4...77024eed99cc5098d33c3ff2b7fdc9e458cfd7f7

- [ ] We still need to get `EXECUTOR_ROLE` on the `UpgradeExecutor` contract.


<ins>Test cases</ins>
- [x] Bridge from EOA to EOA-> should should trigger withdrawal back to L1
Bridge from EOA to Kinto Wallet (when EOA is not whitelisted) -> should trigger withdrawal back to L1
- [x] Bridge from EOA to Kinto Wallet (when EOA is whitelisted) -> should work
- [x] Bridge from EOA to Kinto Wallet (when EOA is an owner) -> should work (because owners are by default whitelisted)
- [x] Bridge from EOA to Bridger L2 contract -> should work
               