### PR TITLE
Remove minimum amount out check from SwapWorkflow

### DIFF
--- a/src/access/workflows/SwapWorkflow.sol
+++ b/src/access/workflows/SwapWorkflow.sol
@@ -44,12 +44,10 @@ contract SwapWorkflow {
      * @param swapCallData The calldata to be sent to the exchange proxy to execute the swap.
      * @return amountOut The actual amount of `tokenOut` received from the swap.
      */
-    function fillQuote(
-        IERC20 tokenIn,
-        uint256 amountIn,
-        IERC20 tokenOut,
-        bytes calldata swapCallData
-    ) external returns (uint256 amountOut) {
+    function fillQuote(IERC20 tokenIn, uint256 amountIn, IERC20 tokenOut, bytes calldata swapCallData)
+        external
+        returns (uint256 amountOut)
+    {
         // Increase the allowance for the exchangeProxy to handle `amountIn` of `tokenIn`
         tokenIn.safeIncreaseAllowance(exchangeProxy, amountIn);
 

--- a/src/access/workflows/SwapWorkflow.sol
+++ b/src/access/workflows/SwapWorkflow.sol
@@ -34,14 +34,13 @@ contract SwapWorkflow {
      * @notice Executes a token swap via the 0x protocol using provided swap calldata.
      * @dev Increases allowance, invokes the swap, and verifies the output. The `swapCallData` should contain all
      * necessary data for executing a swap on 0x. It does not verify if the parameters match the `swapCallData`.
-     * The slippage set at the `quote` from the 0x API request must be equal to or less than `minAmountOut`.
+     * Set the slippage at the "quote," as it is relative to the market price of the asset..
      * The `takerAddress` must be set to the access point's address in the quote to enable RFQ liquidity.
      * Both `allowanceTarget` and `to` are always set to the 0x exchange proxy.
      * For more details, visit: https://0x.org/docs/0x-swap-api/api-references/get-swap-v1-quote
      * @param tokenIn The token being swapped.
      * @param amountIn The amount of `tokenIn` being swapped.
      * @param tokenOut The token expected to be received from the swap.
-     * @param minAmountOut The minimum amount of `tokenOut` that must be received.
      * @param swapCallData The calldata to be sent to the exchange proxy to execute the swap.
      * @return amountOut The actual amount of `tokenOut` received from the swap.
      */
@@ -49,7 +48,6 @@ contract SwapWorkflow {
         IERC20 tokenIn,
         uint256 amountIn,
         IERC20 tokenOut,
-        uint256 minAmountOut,
         bytes calldata swapCallData
     ) external returns (uint256 amountOut) {
         // Increase the allowance for the exchangeProxy to handle `amountIn` of `tokenIn`
@@ -63,11 +61,6 @@ contract SwapWorkflow {
 
         // Calculate the output amount by subtracting the pre-swap balance from the post-swap balance.
         amountOut = tokenOut.balanceOf(address(this)) - balanceBeforeSwap;
-
-        // Revert the transaction if the amount received is less than the minimum acceptable output.
-        if (amountOut < minAmountOut) {
-            revert AmountOutTooLow(amountOut, minAmountOut);
-        }
 
         // Emit an event to log the successful swap.
         emit SwapExecuted(address(tokenIn), amountIn, address(tokenOut), amountOut);

--- a/test/workflows/SwapWorkflow.t.sol
+++ b/test/workflows/SwapWorkflow.t.sol
@@ -93,29 +93,6 @@ contract SwapWorkflowTest is UserOp, SharedSetup {
         assertEq(workflow.exchangeProxy(), EXCHANGE_PROXY);
     }
 
-    function testSwap_RevertWhen_AmountOutTooLow() public {
-        if (!fork) vm.skip(true);
-
-        uint256 amountIn = 1e3 * 1e6;
-        uint256 minAmountOut = amountIn * 1e12;
-        uint256 expectedAmountOut = 999842220668049737510;
-        // block number in which the 0x API data was fetched
-        vm.rollFork(19725885);
-        deploy();
-
-        // Run to regenerate
-        // curl 'https://api.0x.org/swap/v1/quote?buyToken=0x6B175474E89094C44Da98b954EedeAC495271d0F&sellToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&sellAmount=1000000000' --header '0x-api-key: KEY' | jq > ./test/data/swap-quote.json
-        string memory quote = vm.readFile("./test/data/swap-quote.json");
-        bytes memory swapCallData = quote.readBytes(".data");
-        bytes memory data =
-            abi.encodeWithSelector(SwapWorkflow.fillQuote.selector, USDC, amountIn, DAI, minAmountOut, swapCallData);
-
-        deal(USDC, address(accessPoint), amountIn);
-        vm.expectRevert(abi.encodeWithSelector(SwapWorkflow.AmountOutTooLow.selector, expectedAmountOut, minAmountOut));
-        vm.prank(_user);
-        accessPoint.execute(address(swapWorkflow), data);
-    }
-
     function testSwapERC20() public {
         if (!fork) vm.skip(true);
 


### PR DESCRIPTION
# Description

This change is necessary to prevent transactions from being reverted due to the fluctuation in asset prices over time. A better strategy would be to set the slippage at the 0x API `quote`.


<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
