### PR TITLE
Issue: removed extra space

### DIFF
--- a/src/liquidity-mining/RewardsDistributor.sol
+++ b/src/liquidity-mining/RewardsDistributor.sol
@@ -103,7 +103,7 @@ contract RewardsDistributor is Initializable, UUPSUpgradeable, ReentrancyGuardUp
     /* ============ Constants & Immutables ============ */
 
     /// @notice Role to update the root.
-    bytes32 public constant UPDATER_ROLE = keccak256("UPDATER_ROLE ");
+    bytes32 public constant UPDATER_ROLE = keccak256("UPDATER_ROLE");
 
     /// @notice Starting time of the mining program.
     uint256 public immutable startTime;


### PR DESCRIPTION
There is an extra space at the end of the string "UPDATER_ROLE " in the keccak256 function and The extra space changes the resulting keccak256 hash, potentially causing mismatches when verifying roles. This could lead to unintended access control issues
